### PR TITLE
Add Bash version guard for cluster creation script

### DIFF
--- a/bin/daylily-create-ephemeral-cluster
+++ b/bin/daylily-create-ephemeral-cluster
@@ -1,4 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+if [[ -z "${BASH_VERSINFO:-}" || "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+    current_version="${BASH_VERSION:-unknown}"
+    echo "❌ daylily-create-ephemeral-cluster requires Bash 4.0 or newer (current: ${current_version})." >&2
+    echo "   Please rerun using a newer Bash interpreter (e.g. \\`brew install bash\\` on macOS)." >&2
+    exit 1
+fi
 
 
 CURR_SHELL=$(. bin/retshell)


### PR DESCRIPTION
## Summary
- run daylily-create-ephemeral-cluster with /usr/bin/env bash to honour PATH overrides
- add a startup guard that requires Bash 4+ and points macOS users to Homebrew bash

## Testing
- ./bin/daylily-create-ephemeral-cluster --help

------
https://chatgpt.com/codex/tasks/task_e_68d0416420dc83319112544029dd226c