### PR TITLE
Surface available AWS profiles when --profile validation fails

### DIFF
--- a/bin/calcuate_spotprice_for_cluster_yaml.py
+++ b/bin/calcuate_spotprice_for_cluster_yaml.py
@@ -50,7 +50,16 @@ def resolve_aws_profile(profile_argument):
 
     available_profiles = [line.strip() for line in result.stdout.splitlines() if line.strip()]
     if profile not in available_profiles:
-        print(f"Error: AWS profile '{profile}' not found. Please set AWS_PROFILE to a valid profile.", file=sys.stderr)
+        available_profiles_display = "\n".join(
+            f"  - {name}" for name in available_profiles
+        ) or "  (no profiles detected)"
+        message = (
+            f"Error: AWS profile '{profile}' not found.\n"
+            "Available profiles detected with `aws configure list-profiles | grep -E '.'`:\n"
+            f"{available_profiles_display}\n"
+            "Please set AWS_PROFILE to a valid profile."
+        )
+        print(message, file=sys.stderr)
         sys.exit(1)
 
     os.environ["AWS_PROFILE"] = profile

--- a/bin/check_current_spot_market_by_zones.py
+++ b/bin/check_current_spot_market_by_zones.py
@@ -280,7 +280,16 @@ def resolve_aws_profile(profile_argument):
 
     available_profiles = [line.strip() for line in result.stdout.splitlines() if line.strip()]
     if profile not in available_profiles:
-        print(f"Error: AWS profile '{profile}' not found. Please set AWS_PROFILE to a valid profile.", file=sys.stderr)
+        available_profiles_display = "\n".join(
+            f"  - {name}" for name in available_profiles
+        ) or "  (no profiles detected)"
+        message = (
+            f"Error: AWS profile '{profile}' not found.\n"
+            "Available profiles detected with `aws configure list-profiles | grep -E '.'`:\n"
+            f"{available_profiles_display}\n"
+            "Please set AWS_PROFILE to a valid profile."
+        )
+        print(message, file=sys.stderr)
         sys.exit(1)
 
     os.environ['AWS_PROFILE'] = profile

--- a/bin/check_current_spot_market_by_zones_wcapacity.py
+++ b/bin/check_current_spot_market_by_zones_wcapacity.py
@@ -273,7 +273,16 @@ def resolve_aws_profile(profile_argument):
 
     available_profiles = [line.strip() for line in result.stdout.splitlines() if line.strip()]
     if profile not in available_profiles:
-        print(f"Error: AWS profile '{profile}' not found. Please set AWS_PROFILE to a valid profile.", file=sys.stderr)
+        available_profiles_display = "\n".join(
+            f"  - {name}" for name in available_profiles
+        ) or "  (no profiles detected)"
+        message = (
+            f"Error: AWS profile '{profile}' not found.\n"
+            "Available profiles detected with `aws configure list-profiles | grep -E '.'`:\n"
+            f"{available_profiles_display}\n"
+            "Please set AWS_PROFILE to a valid profile."
+        )
+        print(message, file=sys.stderr)
         sys.exit(1)
 
     os.environ['AWS_PROFILE'] = profile

--- a/bin/create_daylily_omics_analysis_s3.sh
+++ b/bin/create_daylily_omics_analysis_s3.sh
@@ -60,7 +60,10 @@ resolve_aws_profile() {
             exit 1
         fi
         if ! grep -Fxq "$final_profile" <<<"$available_profiles"; then
-            echo "Error: AWS profile '$final_profile' not found. Please set AWS_PROFILE to a valid profile." >&2
+            echo "Error: AWS profile '$final_profile' not found." >&2
+            echo "Available profiles detected with \"aws configure list-profiles | grep -E '.'\":" >&2
+            echo "$available_profiles" | grep -E '.' | sed 's/^/  - /' >&2
+            echo "Please set AWS_PROFILE to a valid profile." >&2
             exit 1
         fi
     else

--- a/bin/daylily-create-ephemeral-cluster
+++ b/bin/daylily-create-ephemeral-cluster
@@ -543,7 +543,10 @@ resolve_aws_profile() {
     fi
 
     if ! grep -Fxq "$final_profile" <<<"$available_profiles"; then
-        echo "❌ Error: AWS profile '$final_profile' not found. Please set AWS_PROFILE to a valid profile." >&2
+        echo "❌ Error: AWS profile '$final_profile' not found." >&2
+        echo "ℹ️ Available profiles detected with \"aws configure list-profiles | grep -E '.'\":" >&2
+        echo "$available_profiles" | grep -E '.' | sed 's/^/  - /' >&2
+        echo "❌ Please set AWS_PROFILE to a valid profile." >&2
         exit 3
     fi
 

--- a/bin/helpers/setup_cluster_heartbeat.py
+++ b/bin/helpers/setup_cluster_heartbeat.py
@@ -79,10 +79,16 @@ def resolve_aws_profile(profile_argument: Optional[str]) -> str:
 
     available_profiles = [line.strip() for line in result.stdout.splitlines() if line.strip()]
     if profile not in available_profiles:
-        print(
-            f"Error: AWS profile '{profile}' not found. Please set AWS_PROFILE to a valid profile.",
-            file=sys.stderr,
+        available_profiles_display = "\n".join(
+            f"  - {name}" for name in available_profiles
+        ) or "  (no profiles detected)"
+        message = (
+            f"Error: AWS profile '{profile}' not found.\n"
+            "Available profiles detected with `aws configure list-profiles | grep -E '.'`:\n"
+            f"{available_profiles_display}\n"
+            "Please set AWS_PROFILE to a valid profile."
         )
+        print(message, file=sys.stderr)
         sys.exit(1)
 
     os.environ["AWS_PROFILE"] = profile


### PR DESCRIPTION
## Summary
- show the AWS CLI profiles detected for the current user whenever profile validation fails in helper scripts
- grep and format the available profile list inside the error message to make recovery guidance clearer

## Testing
- python -m compileall bin/helpers/setup_cluster_heartbeat.py bin/check_current_spot_market_by_zones.py bin/check_current_spot_market_by_zones_wcapacity.py bin/calcuate_spotprice_for_cluster_yaml.py


------
https://chatgpt.com/codex/tasks/task_e_68d065eb63a88331adfa0debf4c730e6