### PR TITLE
[codex] Patch SCRATCH_2 FSx size choices

### DIFF
--- a/daylily_ec/workflow/create_cluster.py
+++ b/daylily_ec/workflow/create_cluster.py
@@ -264,8 +264,18 @@ def _prompt_select(label: str, choices: List[str]) -> str:
         typer.echo("Invalid selection. Enter one of the listed numbers.")
 
 
-FSX_SIZE_INCREMENT_GIB = 1200
-FSX_PROMPT_OPTIONS = [str(FSX_SIZE_INCREMENT_GIB * i) for i in range(1, 6)]
+FSX_PROMPT_OPTIONS = [
+    "1200",
+    "2400",
+    "4800",
+    "7200",
+    "9600",
+    "12000",
+    "14400",
+]
+FSX_SIZE_RULE_TEXT = (
+    "1200 GiB, 2400 GiB, or any value >= 4800 GiB divisible by 2400 GiB"
+)
 
 
 def _is_valid_fsx_size(value: str) -> bool:
@@ -273,7 +283,9 @@ def _is_valid_fsx_size(value: str) -> bool:
     if not value or not value.isdigit():
         return False
     size = int(value)
-    return size > 0 and size % FSX_SIZE_INCREMENT_GIB == 0
+    if size == 1200 or size == 2400:
+        return True
+    return size >= 4800 and size % 2400 == 0
 
 
 def _resolve_fsx_size(cfg: Any, *, non_interactive: bool) -> str:
@@ -290,7 +302,7 @@ def _resolve_fsx_size(cfg: Any, *, non_interactive: bool) -> str:
             return configured
         raise ValueError(
             "Invalid FSx size "
-            f"'{configured}'. Allowed sizes are positive multiples of {FSX_SIZE_INCREMENT_GIB} GiB."
+            f"'{configured}'. Allowed sizes are {FSX_SIZE_RULE_TEXT}."
         )
 
     if default_value:
@@ -298,7 +310,7 @@ def _resolve_fsx_size(cfg: Any, *, non_interactive: bool) -> str:
         if not _is_valid_fsx_size(default_value):
             raise ValueError(
                 "Invalid FSx size "
-                f"'{default_value}'. Allowed sizes are positive multiples of {FSX_SIZE_INCREMENT_GIB} GiB."
+                f"'{default_value}'. Allowed sizes are {FSX_SIZE_RULE_TEXT}."
             )
 
     if non_interactive:
@@ -321,7 +333,8 @@ def _resolve_fsx_size(cfg: Any, *, non_interactive: bool) -> str:
         if _is_valid_fsx_size(raw):
             return raw
         typer.echo(
-            f"Invalid FSx size. Enter one of the listed numbers or a positive multiple of {FSX_SIZE_INCREMENT_GIB}."
+            "Invalid FSx size. Enter one of the listed numbers or a value matching: "
+            f"{FSX_SIZE_RULE_TEXT}."
         )
 
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import daylily_ec.aws.cloudformation as cloudformation
 import daylily_ec.aws.context as aws_context
 import daylily_ec.aws.ec2 as aws_ec2
@@ -184,11 +186,10 @@ class TestWorkflowResolutionHelpers:
         )
 
     def test_is_valid_fsx_size(self):
-        assert _is_valid_fsx_size("1200") is True
-        assert _is_valid_fsx_size("6000") is True
-        assert _is_valid_fsx_size("1250") is False
-        assert _is_valid_fsx_size("abc") is False
-        assert _is_valid_fsx_size("0") is False
+        for size in ("1200", "2400", "4800", "7200", "9600", "12000", "14400"):
+            assert _is_valid_fsx_size(size) is True
+        for size in ("3600", "6000", "1250", "abc", "0"):
+            assert _is_valid_fsx_size(size) is False
 
     def test_resolve_fsx_size_uses_valid_default(self):
         cfg = ConfigFile.model_validate(
@@ -202,26 +203,22 @@ class TestWorkflowResolutionHelpers:
 
         assert _resolve_fsx_size(cfg, non_interactive=True) == "4800"
 
-    def test_resolve_fsx_size_rejects_invalid_default(self):
+    @pytest.mark.parametrize("default_value", ["3600", "6000", "1250"])
+    def test_resolve_fsx_size_rejects_invalid_default(self, default_value):
         cfg = ConfigFile.model_validate(
             {
                 "ephemeral_cluster": {
-                    "config": {"fsx_fs_size": ["PROMPTUSER", "1250", ""]},
+                    "config": {"fsx_fs_size": ["PROMPTUSER", default_value, ""]},
                     "template_defaults": {},
                 }
             }
         )
 
         with patch("daylily_ec.workflow.create_cluster.typer.echo"):
-            try:
+            with pytest.raises(ValueError, match=rf"Invalid FSx size '{default_value}'"):
                 _resolve_fsx_size(cfg, non_interactive=True)
-            except ValueError as exc:
-                assert "Invalid FSx size '1250'" in str(exc)
-            else:
-                raise AssertionError("Expected ValueError")
 
-    @patch("daylily_ec.workflow.create_cluster.typer.prompt", return_value="2")
-    def test_resolve_fsx_size_prompts_with_menu(self, mock_prompt):
+    def test_resolve_fsx_size_prompts_with_menu(self):
         cfg = ConfigFile.model_validate(
             {
                 "ephemeral_cluster": {
@@ -231,7 +228,41 @@ class TestWorkflowResolutionHelpers:
             }
         )
 
-        assert _resolve_fsx_size(cfg, non_interactive=False) == "2400"
+        with (
+            patch("daylily_ec.workflow.create_cluster.typer.prompt", return_value="2") as mock_prompt,
+            patch("daylily_ec.workflow.create_cluster.typer.echo") as mock_echo,
+        ):
+            assert _resolve_fsx_size(cfg, non_interactive=False) == "2400"
+
+        assert [call.args[0] for call in mock_echo.call_args_list] == [
+            "Choose FSx Lustre file system size (GiB).",
+            "Smallest allowed sizes:",
+            "  [1] 1200",
+            "  [2] 2400",
+            "  [3] 4800",
+            "  [4] 7200",
+            "  [5] 9600",
+            "  [6] 12000",
+            "  [7] 14400",
+        ]
+        mock_prompt.assert_called_once()
+
+    def test_resolve_fsx_size_accepts_explicit_valid_size(self):
+        cfg = ConfigFile.model_validate(
+            {
+                "ephemeral_cluster": {
+                    "config": {"fsx_fs_size": ["PROMPTUSER", "", ""]},
+                    "template_defaults": {},
+                }
+            }
+        )
+
+        with (
+            patch("daylily_ec.workflow.create_cluster.typer.prompt", return_value="9600") as mock_prompt,
+            patch("daylily_ec.workflow.create_cluster.typer.echo"),
+        ):
+            assert _resolve_fsx_size(cfg, non_interactive=False) == "9600"
+
         mock_prompt.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- restrict FSx size validation in the create workflow to valid `SCRATCH_2` capacities only
- replace the interactive size menu with the exact supported options through `14400`
- update workflow tests to cover the corrected rule, menu rendering, and explicit typed sizes

## Why
The production cluster template uses `SCRATCH_2`, but the CLI prompt and validator still accepted invalid capacities such as `3600` and `6000`. This made the operator prompt inaccurate and allowed non-supported values through validation.

## User impact
Interactive create now offers only valid `SCRATCH_2` capacities, and non-interactive/default resolution rejects invalid capacities with accurate error text. Spot-pricing behavior is unchanged.

## Validation
- `pytest -q tests/test_workflow.py`