### PR TITLE
Fix headnode catalog parsing and bootstrap reruns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,10 @@
 - Interactive sessions must use `SSM-SessionManagerRunShell` configured with `runAsDefaultUser=ubuntu` and bash login-shell behavior.
 - Command payloads must go through the central `daylily_ec.aws.ssm.run_shell` and `daylily_ec.aws.ssm.write_remote_text` helpers rather than ad hoc `aws ssm send-command` calls.
 
+# Local Environment
+
+- Use the repo activation flow before running Daylily commands. If the `DAY-EC` Conda environment is not present or dependencies are missing, run `source ./activate` from the repo root to create/activate it, then use the `DAY-EC` environment for tests and CLI commands.
+
 # ParallelCluster CLI
 
 - `pcluster` is not an `aws` CLI subcommand. Do not pass AWS CLI-only flags such as `--json` to `pcluster`; ParallelCluster commands emit JSON by default.

--- a/bin/headnode_utils/day-clone
+++ b/bin/headnode_utils/day-clone
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from typing import Any, Dict, List, Optional, Tuple
 
+import yaml
+
 
 CONFIG_DIR = os.path.expanduser("~/.config/daylily")
 GLOBAL_CONFIG_PATH = os.path.join(CONFIG_DIR, "daylily_cli_global.yaml")
@@ -18,98 +20,37 @@ class ConfigError(RuntimeError):
     """Raised when configuration files are missing or malformed."""
 
 
-def _strip_inline_comment(value: str) -> str:
-    """Remove inline comments that are not within quotes."""
-    in_single = False
-    in_double = False
-    for idx, char in enumerate(value):
-        if char == "'" and not in_double:
-            in_single = not in_single
-        elif char == '"' and not in_single:
-            in_double = not in_double
-        elif char == '#' and not in_single and not in_double:
-            return value[:idx].rstrip()
-    return value
-
-
-def _parse_simple_yaml(path: str) -> Dict[str, Any]:
-    """Parse a minimal subset of YAML containing nested dictionaries.
-
-    This parser is intentionally lightweight and supports the structures used
-    in the Daylily configuration files. It handles key/value pairs and nested
-    dictionaries that rely on indentation. Lists and complex YAML constructs
-    are intentionally unsupported.
-    """
+def _load_yaml_mapping(path: str) -> Dict[str, Any]:
+    """Load a YAML file that must contain a mapping at the top level."""
     if not os.path.exists(path):
         raise ConfigError(f"Configuration file not found: {path}")
 
-    root: Dict[str, Any] = {}
-    stack: List[Tuple[Dict[str, Any], int]] = [(root, -1)]
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = yaml.safe_load(handle)
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"Invalid YAML in {path}: {exc}") from exc
 
-    with open(path, "r", encoding="utf-8") as handle:
-        for lineno, raw_line in enumerate(handle, start=1):
-            if not raw_line.strip():
-                continue
-            stripped = raw_line.strip()
-            if stripped.startswith("#") or stripped == "---":
-                continue
-
-            indent = len(raw_line) - len(raw_line.lstrip(" "))
-            while stack and indent <= stack[-1][1]:
-                stack.pop()
-            parent = stack[-1][0]
-
-            if ":" not in stripped:
-                raise ConfigError(
-                    f"Invalid line in {path}:{lineno}: '{raw_line.rstrip()}'"
-                )
-
-            key, value = stripped.split(":", 1)
-            key = key.strip()
-            value = _strip_inline_comment(value).strip()
-
-            if not key:
-                raise ConfigError(
-                    f"Missing key in {path}:{lineno}: '{raw_line.rstrip()}'"
-                )
-
-            if not value:
-                new_dict: Dict[str, Any] = {}
-                parent[key] = new_dict
-                stack.append((new_dict, indent))
-                continue
-
-            if (value.startswith('"') and value.endswith('"')) or (
-                value.startswith("'") and value.endswith("'")
-            ):
-                value = value[1:-1]
-
-            parent[key] = value
-
-    return root
+    if not isinstance(payload, dict):
+        raise ConfigError(f"Configuration file must contain a YAML mapping: {path}")
+    return payload
 
 
 def load_global_config() -> Dict[str, Any]:
-    config = _parse_simple_yaml(GLOBAL_CONFIG_PATH)
+    config = _load_yaml_mapping(GLOBAL_CONFIG_PATH)
     if "daylily" not in config:
-        raise ConfigError(
-            f"Missing 'daylily' section in {GLOBAL_CONFIG_PATH}."
-        )
+        raise ConfigError(f"Missing 'daylily' section in {GLOBAL_CONFIG_PATH}.")
     return config["daylily"]
 
 
 def load_available_repos() -> Tuple[str, Dict[str, Dict[str, Any]]]:
-    config = _parse_simple_yaml(AVAILABLE_REPOS_PATH)
+    config = _load_yaml_mapping(AVAILABLE_REPOS_PATH)
     repositories = config.get("repositories")
     if not isinstance(repositories, dict) or not repositories:
-        raise ConfigError(
-            f"No repositories defined in {AVAILABLE_REPOS_PATH}."
-        )
+        raise ConfigError(f"No repositories defined in {AVAILABLE_REPOS_PATH}.")
     default_repo = config.get("default_repository")
     if not default_repo:
-        raise ConfigError(
-            f"Missing default_repository in {AVAILABLE_REPOS_PATH}."
-        )
+        raise ConfigError(f"Missing default_repository in {AVAILABLE_REPOS_PATH}.")
     return default_repo, repositories
 
 
@@ -129,9 +70,7 @@ def clone_repository(
     try:
         subprocess.run(cmd, check=True)
     except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            f"Git clone failed with exit code {exc.returncode}."
-        ) from exc
+        raise RuntimeError(f"Git clone failed with exit code {exc.returncode}.") from exc
 
 
 def derive_default_path(repo_url: str) -> str:

--- a/config/day_cluster/post_install_ubuntu_combined.sh
+++ b/config/day_cluster/post_install_ubuntu_combined.sh
@@ -8,11 +8,39 @@
 # This initializes many useful env vars (cfn_node_type, stack_name, region, etc) need to use this more correctly below
 . "/etc/parallelcluster/cfnconfig"
 
-touch /tmp/$(hostname).postinstallBEGIN
+set -Ee -o pipefail
 
+# ParallelCluster compute custom actions may run without HOME in the environment.
+export HOME="${HOME:-/root}"
+
+timestamp=$(date +"%Y%m%d_%H%M%S")
+node_type="${cfn_node_type:-unknown}"
+node_type_slug="$(echo "${node_type}" | tr '[:upper:]' '[:lower:]')"
+local_log_dir="/var/log/daylily"
+local_log_fn="${local_log_dir}/$(hostname)_${node_type_slug}_${timestamp}_postinstall.log"
+mkdir -p "${local_log_dir}"
+if [ -d /fsx ]; then
+  mkdir -p /fsx/logs
+  chmod -R a+wrx /fsx/logs
+  fsx_log_fn="/fsx/logs/$(hostname)_${node_type_slug}_${timestamp}.log"
+  exec > >(tee -a "${local_log_fn}" "${fsx_log_fn}") 2>&1
+else
+  exec > >(tee -a "${local_log_fn}") 2>&1
+fi
+trap 'rc=$?; echo "[$(date +%Y%m%d_%H%M%S)] ERROR rc=${rc} line=${LINENO}: ${BASH_COMMAND}"; exit ${rc}' ERR
+
+touch /tmp/$(hostname).postinstallBEGIN
 
 region="$1"
 bucket="$2"  # specified in the cluster yaml, bucket-name, no s3:// prefix
+apptainer_deb="/fsx/data/cached_envs/apptainer_1.4.5_amd64.deb"
+apptainer_deb_sha256="70f19af846501acfbc2e42e7cfeee9ee11ddbbfa1c3502d0d99cde34e8e0af05"
+
+echo "[$timestamp] Running post_install_ubuntu_combined.sh ${region} ${bucket} on $(hostname) as ${node_type}"
+echo "[$timestamp] Local log: ${local_log_fn}"
+if [ "${fsx_log_fn:-}" ]; then
+  echo "[$timestamp] FSx log: ${fsx_log_fn}"
+fi
 
 aws configure set region $region
 
@@ -50,11 +78,47 @@ log_spot_price() {
   echo "$(date '+%Y-%m-%d %H:%M:%S') - Region: $region, AZ: $availability_zone, Instance type: $instance_type, Spot price: $spot_price USD/hour" >> "$log_file"
 }
 
+append_once() {
+  local line="$1"
+  local file="$2"
+  grep -Fxq "$line" "$file" 2>/dev/null || echo "$line" >> "$file"
+}
+
+link_cached_entries() {
+  local source_dir="$1"
+  local dest_dir="$2"
+  local requirement="${3:-required}"
+
+  mkdir -p "$dest_dir"
+  shopt -s nullglob
+  local source_paths=("${source_dir}"/*)
+  shopt -u nullglob
+  if [ "${#source_paths[@]}" -eq 0 ]; then
+    if [ "${requirement}" = "optional" ]; then
+      echo "No optional cached entries found under ${source_dir}; skipping"
+      return 0
+    fi
+    echo "ERROR: no cached entries found under ${source_dir}" >&2
+    exit 1
+  fi
+
+  for source_path in "${source_paths[@]}"; do
+    local dest_path="${dest_dir}/$(basename "${source_path}")"
+    if [ -e "${dest_path}" ] || [ -L "${dest_path}" ]; then
+      echo "Cached entry already present, leaving in place: ${dest_path}"
+    else
+      ln -s "${source_path}" "${dest_path}"
+    fi
+  done
+}
+
 
 # GLOBAL ACTIONS HeadNode and ComputeFleet
 
 mkdir -p /tmp/jobs
 chmod -R a+wrx /tmp/jobs
+mkdir -p /fsx/scratch
+chmod -R a+wrx /fsx/scratch
 
 # Configure hugepages and namespaces (common to both head and compute nodes)
 echo "vm.nr_hugepages=2048" | tee -a /etc/sysctl.conf
@@ -70,39 +134,35 @@ log_spot_price
 
 # Update and install necessary packages
 export DEBIAN_FRONTEND=noninteractive
-apt update -y
-apt install -y tmux emacs rclone parallel atop htop glances fd-find docker.io \
+apt-get update
+apt-get install -y tmux emacs rclone parallel atop htop glances fd-find docker.io \
                     build-essential libssl-dev uuid-dev libgpgme-dev squashfs-tools \
                     libseccomp-dev pkg-config openjdk-11-jdk wget unzip nasm yasm isal \
                     fuse2fs gocryptfs cpulimit golang-go numactl
 
-# Add Apptainer PPA
-add-apt-repository -y ppa:apptainer/ppa
-
-# Update package lists
-apt update
-
-# Install Apptainer
-apt install -y apptainer
+# Install Apptainer from the FSx/S3-backed cache. Do not depend on live Launchpad/PPA reachability.
+if [ ! -s "${apptainer_deb}" ]; then
+  echo "ERROR: cached Apptainer deb not found: ${apptainer_deb}" >&2
+  echo "Expected S3 source: s3://${bucket}/data/cached_envs/$(basename "${apptainer_deb}")" >&2
+  exit 1
+fi
+echo "${apptainer_deb_sha256}  ${apptainer_deb}" | sha256sum -c -
+apt-get install -y "${apptainer_deb}"
+if command -v apptainer >/dev/null 2>&1 && ! command -v singularity >/dev/null 2>&1; then
+  ln -sfn "$(command -v apptainer)" /usr/local/bin/singularity
+fi
+command -v apptainer
+command -v singularity
 
 # Install Cromwell and Go (using cached versions)
-ln -s /fsx/data/tool_specific_resources/cromwell_87.jar /usr/local/bin/cromwell.jar
-ln -s /fsx/data/tool_specific_resources/womtool_87.jar /usr/local/bin/womtool.jar
+ln -sfn /fsx/data/tool_specific_resources/cromwell_87.jar /usr/local/bin/cromwell.jar
+ln -sfn /fsx/data/tool_specific_resources/womtool_87.jar /usr/local/bin/womtool.jar
 chmod a+r /usr/local/bin/cromwell.jar /usr/local/bin/womtool.jar
 
 
 if [ "${cfn_node_type}" == "HeadNode" ];then
 
-  # Get the current date and time in seconds
-  timestamp=$(date +"%Y%m%d_%H%M%S")
-
-  # Construct the log filename with the timestamp
-  mkdir -p /fsx/logs
-  chmod -R a+wrx /fsx/logs
-  head_log_fn=/fsx/logs/$(hostname)_head_$timestamp.log
-
-  # Log message with timestamp
-  echo "[$timestamp] Running post_install_ubuntu_combined.sh $region $bucket on $(hostname)" > $head_log_fn
+  echo "[$(date +%Y%m%d_%H%M%S)] Running HeadNode post-install actions"
   
 
   # Create necessary directories
@@ -121,18 +181,26 @@ if [ "${cfn_node_type}" == "HeadNode" ];then
 
   # Copy cached data from S3
 
-  ln -s /fsx/data/cached_envs/conda/* /fsx/resources/environments/conda/ubuntu/$(hostname)/
-  ln -s /fsx/data/cached_envs/containers/* /fsx/resources/environments/containers/ubuntu/$(hostname)/
-  ln -s /fsx/data/cached_envs/conda/* /fsx/resources/environments/conda/daylily/$(hostname)/
-  ln -s /fsx/data/cached_envs/containers/* /fsx/resources/environments/containers/daylily/$(hostname)/
+  link_cached_entries /fsx/data/cached_envs/conda /fsx/resources/environments/conda/ubuntu/$(hostname) required
+  link_cached_entries /fsx/data/cached_envs/containers /fsx/resources/environments/containers/ubuntu/$(hostname) optional
+  link_cached_entries /fsx/data/cached_envs/conda /fsx/resources/environments/conda/daylily/$(hostname) required
+  link_cached_entries /fsx/data/cached_envs/containers /fsx/resources/environments/containers/daylily/$(hostname) optional
 
 
-  mv /opt/slurm/bin/sbatch /opt/slurm/sbin/sbatch
+  if [ ! -e /opt/slurm/sbin/sbatch ]; then
+    mv /opt/slurm/bin/sbatch /opt/slurm/sbin/sbatch
+  else
+    echo "Original sbatch already present: /opt/slurm/sbin/sbatch"
+  fi
   aws s3 cp s3://${bucket}/cluster_boot_config/sbatch /opt/slurm/bin/sbatch
   chmod +x /opt/slurm/bin/sbatch
 
-  mv /opt/slurm/bin/srun /opt/slurm/sbin/srun
-  ln -s /opt/slurm/bin/sbatch /opt/slurm/bin/srun
+  if [ ! -e /opt/slurm/sbin/srun ]; then
+    mv /opt/slurm/bin/srun /opt/slurm/sbin/srun
+  else
+    echo "Original srun already present: /opt/slurm/sbin/srun"
+  fi
+  ln -sfn /opt/slurm/bin/sbatch /opt/slurm/bin/srun
 
   aws s3 cp s3://${bucket}/cluster_boot_config/sleep_test.sh /opt/slurm/bin/sleep_test.sh
   chmod a+x /opt/slurm/bin/sleep_test.sh
@@ -284,9 +352,9 @@ EOF
    chmod a+x /opt/slurm/sbin/epilog.sh
    
    # Configure slurm to use Prolog and Epilog
-   echo "PrologFlags=Alloc" >> /opt/slurm/etc/slurm.conf
-   echo "Prolog=/opt/slurm/sbin/prolog.sh" >> /opt/slurm/etc/slurm.conf
-   echo "Epilog=/opt/slurm/sbin/epilog.sh" >> /opt/slurm/etc/slurm.conf
+   append_once "PrologFlags=Alloc" /opt/slurm/etc/slurm.conf
+   append_once "Prolog=/opt/slurm/sbin/prolog.sh" /opt/slurm/etc/slurm.conf
+   append_once "Epilog=/opt/slurm/sbin/epilog.sh" /opt/slurm/etc/slurm.conf
    
    systemctl restart slurmctld
 fi

--- a/config/daylily_available_repositories.yaml
+++ b/config/daylily_available_repositories.yaml
@@ -7,7 +7,7 @@ repositories:
     description: "Primary whole genome and multiomics workflows."
     https_url: https://github.com/Daylily-Informatics/daylily-omics-analysis.git
     ssh_url: git@github.com:Daylily-Informatics/daylily-omics-analysis.git
-    default_ref: 0.7.708
+    default_ref: 0.7.713
     relative_path: daylily-omics-analysis
     analysis_commands:
       - command_id: illumina_snv_alignstats

--- a/config/daylily_cli_global.yaml
+++ b/config/daylily_cli_global.yaml
@@ -1,7 +1,7 @@
 ---
 daylily:
-  git_ephemeral_cluster_repo_tag: 2.1.11
-  git_ephemeral_cluster_repo_release_tag: 2.1.11
+  git_ephemeral_cluster_repo_tag: 2.1.13
+  git_ephemeral_cluster_repo_release_tag: 2.1.13
   git_ephemeral_cluster_repo: https://github.com/Daylily-Informatics/daylily-ephemeral-cluster.git
   analysis_root: /fsx/analysis_results/
   sentieon_lic_path: /fsx/data/cached_envs/x.lic

--- a/daylily_ec/resources/payload/bin/headnode_utils/day-clone
+++ b/daylily_ec/resources/payload/bin/headnode_utils/day-clone
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from typing import Any, Dict, List, Optional, Tuple
 
+import yaml
+
 
 CONFIG_DIR = os.path.expanduser("~/.config/daylily")
 GLOBAL_CONFIG_PATH = os.path.join(CONFIG_DIR, "daylily_cli_global.yaml")
@@ -18,98 +20,37 @@ class ConfigError(RuntimeError):
     """Raised when configuration files are missing or malformed."""
 
 
-def _strip_inline_comment(value: str) -> str:
-    """Remove inline comments that are not within quotes."""
-    in_single = False
-    in_double = False
-    for idx, char in enumerate(value):
-        if char == "'" and not in_double:
-            in_single = not in_single
-        elif char == '"' and not in_single:
-            in_double = not in_double
-        elif char == '#' and not in_single and not in_double:
-            return value[:idx].rstrip()
-    return value
-
-
-def _parse_simple_yaml(path: str) -> Dict[str, Any]:
-    """Parse a minimal subset of YAML containing nested dictionaries.
-
-    This parser is intentionally lightweight and supports the structures used
-    in the Daylily configuration files. It handles key/value pairs and nested
-    dictionaries that rely on indentation. Lists and complex YAML constructs
-    are intentionally unsupported.
-    """
+def _load_yaml_mapping(path: str) -> Dict[str, Any]:
+    """Load a YAML file that must contain a mapping at the top level."""
     if not os.path.exists(path):
         raise ConfigError(f"Configuration file not found: {path}")
 
-    root: Dict[str, Any] = {}
-    stack: List[Tuple[Dict[str, Any], int]] = [(root, -1)]
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = yaml.safe_load(handle)
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"Invalid YAML in {path}: {exc}") from exc
 
-    with open(path, "r", encoding="utf-8") as handle:
-        for lineno, raw_line in enumerate(handle, start=1):
-            if not raw_line.strip():
-                continue
-            stripped = raw_line.strip()
-            if stripped.startswith("#") or stripped == "---":
-                continue
-
-            indent = len(raw_line) - len(raw_line.lstrip(" "))
-            while stack and indent <= stack[-1][1]:
-                stack.pop()
-            parent = stack[-1][0]
-
-            if ":" not in stripped:
-                raise ConfigError(
-                    f"Invalid line in {path}:{lineno}: '{raw_line.rstrip()}'"
-                )
-
-            key, value = stripped.split(":", 1)
-            key = key.strip()
-            value = _strip_inline_comment(value).strip()
-
-            if not key:
-                raise ConfigError(
-                    f"Missing key in {path}:{lineno}: '{raw_line.rstrip()}'"
-                )
-
-            if not value:
-                new_dict: Dict[str, Any] = {}
-                parent[key] = new_dict
-                stack.append((new_dict, indent))
-                continue
-
-            if (value.startswith('"') and value.endswith('"')) or (
-                value.startswith("'") and value.endswith("'")
-            ):
-                value = value[1:-1]
-
-            parent[key] = value
-
-    return root
+    if not isinstance(payload, dict):
+        raise ConfigError(f"Configuration file must contain a YAML mapping: {path}")
+    return payload
 
 
 def load_global_config() -> Dict[str, Any]:
-    config = _parse_simple_yaml(GLOBAL_CONFIG_PATH)
+    config = _load_yaml_mapping(GLOBAL_CONFIG_PATH)
     if "daylily" not in config:
-        raise ConfigError(
-            f"Missing 'daylily' section in {GLOBAL_CONFIG_PATH}."
-        )
+        raise ConfigError(f"Missing 'daylily' section in {GLOBAL_CONFIG_PATH}.")
     return config["daylily"]
 
 
 def load_available_repos() -> Tuple[str, Dict[str, Dict[str, Any]]]:
-    config = _parse_simple_yaml(AVAILABLE_REPOS_PATH)
+    config = _load_yaml_mapping(AVAILABLE_REPOS_PATH)
     repositories = config.get("repositories")
     if not isinstance(repositories, dict) or not repositories:
-        raise ConfigError(
-            f"No repositories defined in {AVAILABLE_REPOS_PATH}."
-        )
+        raise ConfigError(f"No repositories defined in {AVAILABLE_REPOS_PATH}.")
     default_repo = config.get("default_repository")
     if not default_repo:
-        raise ConfigError(
-            f"Missing default_repository in {AVAILABLE_REPOS_PATH}."
-        )
+        raise ConfigError(f"Missing default_repository in {AVAILABLE_REPOS_PATH}.")
     return default_repo, repositories
 
 
@@ -129,9 +70,7 @@ def clone_repository(
     try:
         subprocess.run(cmd, check=True)
     except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            f"Git clone failed with exit code {exc.returncode}."
-        ) from exc
+        raise RuntimeError(f"Git clone failed with exit code {exc.returncode}.") from exc
 
 
 def derive_default_path(repo_url: str) -> str:

--- a/daylily_ec/resources/payload/config/day_cluster/post_install_ubuntu_combined.sh
+++ b/daylily_ec/resources/payload/config/day_cluster/post_install_ubuntu_combined.sh
@@ -8,11 +8,39 @@
 # This initializes many useful env vars (cfn_node_type, stack_name, region, etc) need to use this more correctly below
 . "/etc/parallelcluster/cfnconfig"
 
-touch /tmp/$(hostname).postinstallBEGIN
+set -Ee -o pipefail
 
+# ParallelCluster compute custom actions may run without HOME in the environment.
+export HOME="${HOME:-/root}"
+
+timestamp=$(date +"%Y%m%d_%H%M%S")
+node_type="${cfn_node_type:-unknown}"
+node_type_slug="$(echo "${node_type}" | tr '[:upper:]' '[:lower:]')"
+local_log_dir="/var/log/daylily"
+local_log_fn="${local_log_dir}/$(hostname)_${node_type_slug}_${timestamp}_postinstall.log"
+mkdir -p "${local_log_dir}"
+if [ -d /fsx ]; then
+  mkdir -p /fsx/logs
+  chmod -R a+wrx /fsx/logs
+  fsx_log_fn="/fsx/logs/$(hostname)_${node_type_slug}_${timestamp}.log"
+  exec > >(tee -a "${local_log_fn}" "${fsx_log_fn}") 2>&1
+else
+  exec > >(tee -a "${local_log_fn}") 2>&1
+fi
+trap 'rc=$?; echo "[$(date +%Y%m%d_%H%M%S)] ERROR rc=${rc} line=${LINENO}: ${BASH_COMMAND}"; exit ${rc}' ERR
+
+touch /tmp/$(hostname).postinstallBEGIN
 
 region="$1"
 bucket="$2"  # specified in the cluster yaml, bucket-name, no s3:// prefix
+apptainer_deb="/fsx/data/cached_envs/apptainer_1.4.5_amd64.deb"
+apptainer_deb_sha256="70f19af846501acfbc2e42e7cfeee9ee11ddbbfa1c3502d0d99cde34e8e0af05"
+
+echo "[$timestamp] Running post_install_ubuntu_combined.sh ${region} ${bucket} on $(hostname) as ${node_type}"
+echo "[$timestamp] Local log: ${local_log_fn}"
+if [ "${fsx_log_fn:-}" ]; then
+  echo "[$timestamp] FSx log: ${fsx_log_fn}"
+fi
 
 aws configure set region $region
 
@@ -50,11 +78,47 @@ log_spot_price() {
   echo "$(date '+%Y-%m-%d %H:%M:%S') - Region: $region, AZ: $availability_zone, Instance type: $instance_type, Spot price: $spot_price USD/hour" >> "$log_file"
 }
 
+append_once() {
+  local line="$1"
+  local file="$2"
+  grep -Fxq "$line" "$file" 2>/dev/null || echo "$line" >> "$file"
+}
+
+link_cached_entries() {
+  local source_dir="$1"
+  local dest_dir="$2"
+  local requirement="${3:-required}"
+
+  mkdir -p "$dest_dir"
+  shopt -s nullglob
+  local source_paths=("${source_dir}"/*)
+  shopt -u nullglob
+  if [ "${#source_paths[@]}" -eq 0 ]; then
+    if [ "${requirement}" = "optional" ]; then
+      echo "No optional cached entries found under ${source_dir}; skipping"
+      return 0
+    fi
+    echo "ERROR: no cached entries found under ${source_dir}" >&2
+    exit 1
+  fi
+
+  for source_path in "${source_paths[@]}"; do
+    local dest_path="${dest_dir}/$(basename "${source_path}")"
+    if [ -e "${dest_path}" ] || [ -L "${dest_path}" ]; then
+      echo "Cached entry already present, leaving in place: ${dest_path}"
+    else
+      ln -s "${source_path}" "${dest_path}"
+    fi
+  done
+}
+
 
 # GLOBAL ACTIONS HeadNode and ComputeFleet
 
 mkdir -p /tmp/jobs
 chmod -R a+wrx /tmp/jobs
+mkdir -p /fsx/scratch
+chmod -R a+wrx /fsx/scratch
 
 # Configure hugepages and namespaces (common to both head and compute nodes)
 echo "vm.nr_hugepages=2048" | tee -a /etc/sysctl.conf
@@ -70,39 +134,35 @@ log_spot_price
 
 # Update and install necessary packages
 export DEBIAN_FRONTEND=noninteractive
-apt update -y
-apt install -y tmux emacs rclone parallel atop htop glances fd-find docker.io \
+apt-get update
+apt-get install -y tmux emacs rclone parallel atop htop glances fd-find docker.io \
                     build-essential libssl-dev uuid-dev libgpgme-dev squashfs-tools \
                     libseccomp-dev pkg-config openjdk-11-jdk wget unzip nasm yasm isal \
                     fuse2fs gocryptfs cpulimit golang-go numactl
 
-# Add Apptainer PPA
-add-apt-repository -y ppa:apptainer/ppa
-
-# Update package lists
-apt update
-
-# Install Apptainer
-apt install -y apptainer
+# Install Apptainer from the FSx/S3-backed cache. Do not depend on live Launchpad/PPA reachability.
+if [ ! -s "${apptainer_deb}" ]; then
+  echo "ERROR: cached Apptainer deb not found: ${apptainer_deb}" >&2
+  echo "Expected S3 source: s3://${bucket}/data/cached_envs/$(basename "${apptainer_deb}")" >&2
+  exit 1
+fi
+echo "${apptainer_deb_sha256}  ${apptainer_deb}" | sha256sum -c -
+apt-get install -y "${apptainer_deb}"
+if command -v apptainer >/dev/null 2>&1 && ! command -v singularity >/dev/null 2>&1; then
+  ln -sfn "$(command -v apptainer)" /usr/local/bin/singularity
+fi
+command -v apptainer
+command -v singularity
 
 # Install Cromwell and Go (using cached versions)
-ln -s /fsx/data/tool_specific_resources/cromwell_87.jar /usr/local/bin/cromwell.jar
-ln -s /fsx/data/tool_specific_resources/womtool_87.jar /usr/local/bin/womtool.jar
+ln -sfn /fsx/data/tool_specific_resources/cromwell_87.jar /usr/local/bin/cromwell.jar
+ln -sfn /fsx/data/tool_specific_resources/womtool_87.jar /usr/local/bin/womtool.jar
 chmod a+r /usr/local/bin/cromwell.jar /usr/local/bin/womtool.jar
 
 
 if [ "${cfn_node_type}" == "HeadNode" ];then
 
-  # Get the current date and time in seconds
-  timestamp=$(date +"%Y%m%d_%H%M%S")
-
-  # Construct the log filename with the timestamp
-  mkdir -p /fsx/logs
-  chmod -R a+wrx /fsx/logs
-  head_log_fn=/fsx/logs/$(hostname)_head_$timestamp.log
-
-  # Log message with timestamp
-  echo "[$timestamp] Running post_install_ubuntu_combined.sh $region $bucket on $(hostname)" > $head_log_fn
+  echo "[$(date +%Y%m%d_%H%M%S)] Running HeadNode post-install actions"
   
 
   # Create necessary directories
@@ -121,18 +181,26 @@ if [ "${cfn_node_type}" == "HeadNode" ];then
 
   # Copy cached data from S3
 
-  ln -s /fsx/data/cached_envs/conda/* /fsx/resources/environments/conda/ubuntu/$(hostname)/
-  ln -s /fsx/data/cached_envs/containers/* /fsx/resources/environments/containers/ubuntu/$(hostname)/
-  ln -s /fsx/data/cached_envs/conda/* /fsx/resources/environments/conda/daylily/$(hostname)/
-  ln -s /fsx/data/cached_envs/containers/* /fsx/resources/environments/containers/daylily/$(hostname)/
+  link_cached_entries /fsx/data/cached_envs/conda /fsx/resources/environments/conda/ubuntu/$(hostname) required
+  link_cached_entries /fsx/data/cached_envs/containers /fsx/resources/environments/containers/ubuntu/$(hostname) optional
+  link_cached_entries /fsx/data/cached_envs/conda /fsx/resources/environments/conda/daylily/$(hostname) required
+  link_cached_entries /fsx/data/cached_envs/containers /fsx/resources/environments/containers/daylily/$(hostname) optional
 
 
-  mv /opt/slurm/bin/sbatch /opt/slurm/sbin/sbatch
+  if [ ! -e /opt/slurm/sbin/sbatch ]; then
+    mv /opt/slurm/bin/sbatch /opt/slurm/sbin/sbatch
+  else
+    echo "Original sbatch already present: /opt/slurm/sbin/sbatch"
+  fi
   aws s3 cp s3://${bucket}/cluster_boot_config/sbatch /opt/slurm/bin/sbatch
   chmod +x /opt/slurm/bin/sbatch
 
-  mv /opt/slurm/bin/srun /opt/slurm/sbin/srun
-  ln -s /opt/slurm/bin/sbatch /opt/slurm/bin/srun
+  if [ ! -e /opt/slurm/sbin/srun ]; then
+    mv /opt/slurm/bin/srun /opt/slurm/sbin/srun
+  else
+    echo "Original srun already present: /opt/slurm/sbin/srun"
+  fi
+  ln -sfn /opt/slurm/bin/sbatch /opt/slurm/bin/srun
 
   aws s3 cp s3://${bucket}/cluster_boot_config/sleep_test.sh /opt/slurm/bin/sleep_test.sh
   chmod a+x /opt/slurm/bin/sleep_test.sh
@@ -284,9 +352,9 @@ EOF
    chmod a+x /opt/slurm/sbin/epilog.sh
    
    # Configure slurm to use Prolog and Epilog
-   echo "PrologFlags=Alloc" >> /opt/slurm/etc/slurm.conf
-   echo "Prolog=/opt/slurm/sbin/prolog.sh" >> /opt/slurm/etc/slurm.conf
-   echo "Epilog=/opt/slurm/sbin/epilog.sh" >> /opt/slurm/etc/slurm.conf
+   append_once "PrologFlags=Alloc" /opt/slurm/etc/slurm.conf
+   append_once "Prolog=/opt/slurm/sbin/prolog.sh" /opt/slurm/etc/slurm.conf
+   append_once "Epilog=/opt/slurm/sbin/epilog.sh" /opt/slurm/etc/slurm.conf
    
    systemctl restart slurmctld
 fi

--- a/daylily_ec/resources/payload/config/daylily_available_repositories.yaml
+++ b/daylily_ec/resources/payload/config/daylily_available_repositories.yaml
@@ -7,7 +7,7 @@ repositories:
     description: "Primary whole genome and multiomics workflows."
     https_url: https://github.com/Daylily-Informatics/daylily-omics-analysis.git
     ssh_url: git@github.com:Daylily-Informatics/daylily-omics-analysis.git
-    default_ref: 0.7.704
+    default_ref: 0.7.713
     relative_path: daylily-omics-analysis
     analysis_commands:
       - command_id: illumina_snv_alignstats

--- a/daylily_ec/resources/payload/config/daylily_cli_global.yaml
+++ b/daylily_ec/resources/payload/config/daylily_cli_global.yaml
@@ -1,7 +1,7 @@
 ---
 daylily:
-  git_ephemeral_cluster_repo_tag: 2.0.2
-  git_ephemeral_cluster_repo_release_tag: 2.0.2
+  git_ephemeral_cluster_repo_tag: 2.1.13
+  git_ephemeral_cluster_repo_release_tag: 2.1.13
   git_ephemeral_cluster_repo: https://github.com/Daylily-Informatics/daylily-ephemeral-cluster.git
   analysis_root: /fsx/analysis_results/
   sentieon_lic_path: /fsx/data/cached_envs/x.lic

--- a/daylily_ec/workflow/create_cluster.py
+++ b/daylily_ec/workflow/create_cluster.py
@@ -34,7 +34,7 @@ from typing import Any, Callable, Dict, List, Optional
 import typer
 
 from daylily_ec import ui
-from daylily_ec.state.models import PreflightReport, StateRecord
+from daylily_ec.state.models import CheckResult, CheckStatus, PreflightReport, StateRecord
 from daylily_ec.state.store import write_preflight_report, write_state_record
 
 logger = logging.getLogger(__name__)
@@ -133,7 +133,9 @@ def _resolve_headnode_repo_spec(default_url: str, default_ref: str) -> HeadnodeR
         text=True,
     )
     if published.returncode != 0:
-        detail = published.stderr.strip() or published.stdout.strip() or "branch not published on origin"
+        detail = (
+            published.stderr.strip() or published.stdout.strip() or "branch not published on origin"
+        )
         raise RuntimeError(
             f"Current checkout branch is not available on origin: {repo_ref} ({detail})"
         )
@@ -249,13 +251,76 @@ def exit_code_for(report: PreflightReport) -> int:
     return EXIT_SUCCESS
 
 
+def _repository_catalog_path() -> Path:
+    """Return the repository catalog path used by local create/headnode setup."""
+    local_catalog = Path("config/daylily_available_repositories.yaml")
+    if local_catalog.exists():
+        return local_catalog
+
+    from daylily_ec.repositories import default_catalog_path
+
+    return default_catalog_path()
+
+
+def make_repository_catalog_preflight_step(
+    catalog_path: Optional[Path] = None,
+) -> PreflightStep:
+    """Validate the repository catalog consumed by ``day-clone`` on headnodes."""
+
+    def step(report: PreflightReport) -> PreflightReport:
+        from daylily_ec.repositories import load_repository_catalog
+
+        path = (
+            Path(catalog_path).expanduser()
+            if catalog_path is not None
+            else _repository_catalog_path()
+        )
+        try:
+            catalog = load_repository_catalog(path)
+        except Exception as exc:
+            report.checks.append(
+                CheckResult(
+                    id="config.repository_catalog",
+                    status=CheckStatus.FAIL,
+                    details={
+                        "path": str(path),
+                        "error": str(exc),
+                    },
+                    remediation=(
+                        f"Fix repository catalog {path}. Headnode configuration would fail "
+                        "because day-clone consumes this file."
+                    ),
+                )
+            )
+            return report
+
+        report.checks.append(
+            CheckResult(
+                id="config.repository_catalog",
+                status=CheckStatus.PASS,
+                details={
+                    "path": str(path),
+                    "command_catalog_version": catalog.command_catalog_version,
+                    "default_repository": catalog.default_repository,
+                    "repository_count": len(catalog.repositories),
+                    "command_count": len(catalog.commands()),
+                },
+            )
+        )
+        return report
+
+    return step
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
 
 def _extract_selected(
-    report: PreflightReport, check_id: str, detail_key: str,
+    report: PreflightReport,
+    check_id: str,
+    detail_key: str,
 ) -> str:
     """Pull a value from report check details (e.g. selected bucket)."""
     for chk in report.checks:
@@ -267,8 +332,13 @@ def _extract_selected(
 def _noop_heartbeat_result() -> Any:
     """Return a stub HeartbeatResult-like object for the no-op path."""
     from types import SimpleNamespace
+
     return SimpleNamespace(
-        success=False, topic_arn="", schedule_name="", role_arn="", error="skipped",
+        success=False,
+        topic_arn="",
+        schedule_name="",
+        role_arn="",
+        error="skipped",
     )
 
 
@@ -298,9 +368,7 @@ FSX_PROMPT_OPTIONS = [
     "12000",
     "14400",
 ]
-FSX_SIZE_RULE_TEXT = (
-    "1200 GiB, 2400 GiB, or any value >= 4800 GiB divisible by 2400 GiB"
-)
+FSX_SIZE_RULE_TEXT = "1200 GiB, 2400 GiB, or any value >= 4800 GiB divisible by 2400 GiB"
 
 
 def _is_valid_fsx_size(value: str) -> bool:
@@ -326,16 +394,14 @@ def _resolve_fsx_size(cfg: Any, *, non_interactive: bool) -> str:
         if _is_valid_fsx_size(configured):
             return configured
         raise ValueError(
-            "Invalid FSx size "
-            f"'{configured}'. Allowed sizes are {FSX_SIZE_RULE_TEXT}."
+            f"Invalid FSx size '{configured}'. Allowed sizes are {FSX_SIZE_RULE_TEXT}."
         )
 
     if default_value:
         default_value = default_value.strip()
         if not _is_valid_fsx_size(default_value):
             raise ValueError(
-                "Invalid FSx size "
-                f"'{default_value}'. Allowed sizes are {FSX_SIZE_RULE_TEXT}."
+                f"Invalid FSx size '{default_value}'. Allowed sizes are {FSX_SIZE_RULE_TEXT}."
             )
 
     if non_interactive:
@@ -426,59 +492,80 @@ def _resolve_post_create_inputs(
     allowed_budget_users_default: str,
 ) -> _PostCreateInputs:
     """Resolve budget and heartbeat inputs once before the create phase."""
-    budget_email = _resolve_config_value(
-        cfg,
-        "budget_email",
-        "Budget email",
-        non_interactive=non_interactive,
-        default_fallback=budget_email_default,
-    ) or budget_email_default
-    budget_amount = _resolve_config_value(
-        cfg,
-        "budget_amount",
-        "Budget amount",
-        non_interactive=non_interactive,
-        default_fallback="200",
-    ) or "200"
-    global_budget_amount = _resolve_config_value(
-        cfg,
-        "global_budget_amount",
-        "Global budget amount",
-        non_interactive=non_interactive,
-        default_fallback="1000",
-    ) or "1000"
-    allowed_budget_users = _resolve_config_value(
-        cfg,
-        "allowed_budget_users",
-        "Allowed budget users",
-        non_interactive=non_interactive,
-        default_fallback=allowed_budget_users_default,
-    ) or allowed_budget_users_default
-    heartbeat_email = _resolve_config_value(
-        cfg,
-        "heartbeat_email",
-        "Heartbeat email",
-        non_interactive=non_interactive,
-        default_fallback=budget_email,
-        required=False,
-        allow_empty=True,
-    ) or budget_email
-    heartbeat_schedule = _resolve_config_value(
-        cfg,
-        "heartbeat_schedule",
-        "Heartbeat schedule",
-        non_interactive=non_interactive,
-        default_fallback="rate(6 hours)",
-        required=False,
-    ) or "rate(6 hours)"
-    heartbeat_scheduler_role_arn = _resolve_config_value(
-        cfg,
-        "heartbeat_scheduler_role_arn",
-        "Heartbeat scheduler role ARN",
-        non_interactive=non_interactive,
-        required=False,
-        allow_empty=True,
-    ) or ""
+    budget_email = (
+        _resolve_config_value(
+            cfg,
+            "budget_email",
+            "Budget email",
+            non_interactive=non_interactive,
+            default_fallback=budget_email_default,
+        )
+        or budget_email_default
+    )
+    budget_amount = (
+        _resolve_config_value(
+            cfg,
+            "budget_amount",
+            "Budget amount",
+            non_interactive=non_interactive,
+            default_fallback="200",
+        )
+        or "200"
+    )
+    global_budget_amount = (
+        _resolve_config_value(
+            cfg,
+            "global_budget_amount",
+            "Global budget amount",
+            non_interactive=non_interactive,
+            default_fallback="1000",
+        )
+        or "1000"
+    )
+    allowed_budget_users = (
+        _resolve_config_value(
+            cfg,
+            "allowed_budget_users",
+            "Allowed budget users",
+            non_interactive=non_interactive,
+            default_fallback=allowed_budget_users_default,
+        )
+        or allowed_budget_users_default
+    )
+    heartbeat_email = (
+        _resolve_config_value(
+            cfg,
+            "heartbeat_email",
+            "Heartbeat email",
+            non_interactive=non_interactive,
+            default_fallback=budget_email,
+            required=False,
+            allow_empty=True,
+        )
+        or budget_email
+    )
+    heartbeat_schedule = (
+        _resolve_config_value(
+            cfg,
+            "heartbeat_schedule",
+            "Heartbeat schedule",
+            non_interactive=non_interactive,
+            default_fallback="rate(6 hours)",
+            required=False,
+        )
+        or "rate(6 hours)"
+    )
+    heartbeat_scheduler_role_arn = (
+        _resolve_config_value(
+            cfg,
+            "heartbeat_scheduler_role_arn",
+            "Heartbeat scheduler role ARN",
+            non_interactive=non_interactive,
+            required=False,
+            allow_empty=True,
+        )
+        or ""
+    )
 
     return _PostCreateInputs(
         budget_email=budget_email,
@@ -595,13 +682,16 @@ def run_create_workflow(
     cfg = load_config(effective_config)
     ec = cfg.ephemeral_cluster
 
-    cluster_name = _resolve_config_value(
-        cfg,
-        "cluster_name",
-        "Cluster name",
-        non_interactive=non_interactive,
-        default_fallback="prod",
-    ) or "prod"
+    cluster_name = (
+        _resolve_config_value(
+            cfg,
+            "cluster_name",
+            "Cluster name",
+            non_interactive=non_interactive,
+            default_fallback="prod",
+        )
+        or "prod"
+    )
 
     ui.phase(f"INIT · {cluster_name}")
 
@@ -638,22 +728,31 @@ def run_create_workflow(
     # Build preflight steps in §10.5 order
     max_8i = int(
         _resolve_config_value(
-            cfg, "max_count_8I", "Max 8xlarge count",
-            non_interactive=non_interactive, default_fallback="1",
+            cfg,
+            "max_count_8I",
+            "Max 8xlarge count",
+            non_interactive=non_interactive,
+            default_fallback="1",
         )
         or "1"
     )
     max_128i = int(
         _resolve_config_value(
-            cfg, "max_count_128I", "Max 128xlarge count",
-            non_interactive=non_interactive, default_fallback="1",
+            cfg,
+            "max_count_128I",
+            "Max 128xlarge count",
+            non_interactive=non_interactive,
+            default_fallback="1",
         )
         or "1"
     )
     max_192i = int(
         _resolve_config_value(
-            cfg, "max_count_192I", "Max 192xlarge count",
-            non_interactive=non_interactive, default_fallback="1",
+            cfg,
+            "max_count_192I",
+            "Max 192xlarge count",
+            non_interactive=non_interactive,
+            default_fallback="1",
         )
         or "1"
     )
@@ -671,7 +770,10 @@ def run_create_workflow(
         # 1-2: ToolchainValidator + AWS Identity — implicit via AWSContext.build
         # 3: IAM Permission Validator
         make_iam_preflight_step(aws_ctx, interactive=not non_interactive),
-        # 4: ConfigValidator — config load already succeeded above
+        # 4: ConfigValidator — config load already succeeded above; validate
+        # the repository catalog before any AWS mutation because headnode
+        # configuration consumes it through day-clone.
+        make_repository_catalog_preflight_step(),
         # 5: QuotaValidator
         make_quota_preflight_step(
             aws_ctx,
@@ -692,7 +794,9 @@ def run_create_workflow(
     ]
 
     report = run_preflight(
-        report, pass_on_warn=pass_on_warn, steps=preflight_steps,
+        report,
+        pass_on_warn=pass_on_warn,
+        steps=preflight_steps,
     )
 
     if should_abort(report, pass_on_warn=pass_on_warn):
@@ -726,38 +830,49 @@ def run_create_workflow(
     pub_t = ec.config.get("public_subnet_id")
     priv_t = ec.config.get("private_subnet_id")
 
-    public_subnet = select_subnet(
-        pub_list,
-        cfg_action=pub_t.action if pub_t else "",
-        cfg_set_value=pub_t.set_value if pub_t else "",
-        cfg_fallback=cfn_outputs.public_subnet_id,
-    ) or cfn_outputs.public_subnet_id
+    public_subnet = (
+        select_subnet(
+            pub_list,
+            cfg_action=pub_t.action if pub_t else "",
+            cfg_set_value=pub_t.set_value if pub_t else "",
+            cfg_fallback=cfn_outputs.public_subnet_id,
+        )
+        or cfn_outputs.public_subnet_id
+    )
     if not public_subnet and not non_interactive and pub_list:
         public_subnet = _prompt_select(
-            "public subnet", [subnet.subnet_id for subnet in pub_list],
+            "public subnet",
+            [subnet.subnet_id for subnet in pub_list],
         )
 
-    private_subnet = select_subnet(
-        priv_list,
-        cfg_action=priv_t.action if priv_t else "",
-        cfg_set_value=priv_t.set_value if priv_t else "",
-        cfg_fallback=cfn_outputs.private_subnet_id,
-    ) or cfn_outputs.private_subnet_id
+    private_subnet = (
+        select_subnet(
+            priv_list,
+            cfg_action=priv_t.action if priv_t else "",
+            cfg_set_value=priv_t.set_value if priv_t else "",
+            cfg_fallback=cfn_outputs.private_subnet_id,
+        )
+        or cfn_outputs.private_subnet_id
+    )
     if not private_subnet and not non_interactive and priv_list:
         private_subnet = _prompt_select(
-            "private subnet", [subnet.subnet_id for subnet in priv_list],
+            "private subnet",
+            [subnet.subnet_id for subnet in priv_list],
         )
 
     # 3c. Policy ARN selection
     iam_client = aws_ctx.client("iam")
     policy_arns = list_pcluster_tags_budget_policies(iam_client)
     iam_t = ec.config.get("iam_policy_arn")
-    policy_arn = select_policy_arn(
-        policy_arns,
-        cfg_action=iam_t.action if iam_t else "",
-        cfg_set_value=iam_t.set_value if iam_t else "",
-        cfg_fallback=cfn_outputs.policy_arn,
-    ) or cfn_outputs.policy_arn
+    policy_arn = (
+        select_policy_arn(
+            policy_arns,
+            cfg_action=iam_t.action if iam_t else "",
+            cfg_set_value=iam_t.set_value if iam_t else "",
+            cfg_fallback=cfn_outputs.policy_arn,
+        )
+        or cfn_outputs.policy_arn
+    )
     if not policy_arn and not non_interactive and policy_arns:
         policy_arn = _prompt_select("IAM policy ARN", policy_arns)
 
@@ -776,7 +891,10 @@ def run_create_workflow(
 
     logger.info(
         "Resources: bucket=%s pub=%s priv=%s policy=%s",
-        bucket_name, public_subnet, private_subnet, policy_arn,
+        bucket_name,
+        public_subnet,
+        private_subnet,
+        policy_arn,
     )
     ui.ok("Resources resolved")
     ui.detail("Bucket", bucket_name)
@@ -796,13 +914,16 @@ def run_create_workflow(
     ui.phase("RENDER CLUSTER YAML")
 
     bucket_url = f"s3://{bucket_name}" if bucket_name else ""
-    template_yaml = _resolve_config_value(
-        cfg,
-        "cluster_template_yaml",
-        "Cluster template YAML",
-        non_interactive=non_interactive,
-        default_fallback="config/day_cluster/prod_cluster.yaml",
-    ) or "config/day_cluster/prod_cluster.yaml"
+    template_yaml = (
+        _resolve_config_value(
+            cfg,
+            "cluster_template_yaml",
+            "Cluster template YAML",
+            non_interactive=non_interactive,
+            default_fallback="config/day_cluster/prod_cluster.yaml",
+        )
+        or "config/day_cluster/prod_cluster.yaml"
+    )
     if not Path(template_yaml).is_file():
         template_yaml = str(resource_path(template_yaml))
 
@@ -815,7 +936,8 @@ def run_create_workflow(
         "REGSUB_PRIVATE_SUBNET": private_subnet,
         "REGSUB_S3_BUCKET_REF": bucket_url,
         "REGSUB_FSX_SIZE": _resolve_fsx_size(
-            cfg, non_interactive=non_interactive,
+            cfg,
+            non_interactive=non_interactive,
         ),
         "REGSUB_DETAILED_MONITORING": _resolve_config_value(
             cfg,
@@ -823,7 +945,8 @@ def run_create_workflow(
             "Enable detailed monitoring",
             non_interactive=non_interactive,
             default_fallback="false",
-        ) or "false",
+        )
+        or "false",
         "REGSUB_CLUSTER_NAME": cluster_name,
         "REGSUB_USERNAME": f"{_os.environ.get('USER', 'unknown')}-{aws_ctx.iam_username}",
         "REGSUB_PROJECT": cluster_name,
@@ -833,7 +956,8 @@ def run_create_workflow(
             "Delete local root",
             non_interactive=non_interactive,
             default_fallback="false",
-        ) or "false",
+        )
+        or "false",
         # DeletionPolicy requires "Retain" or "Delete", not bool.
         "REGSUB_SAVE_FSX": (
             "Delete"
@@ -846,11 +970,13 @@ def run_create_workflow(
                     default_fallback="Delete",
                 )
                 or "false"
-            ).lower() in ("true", "1", "yes", "delete")
+            ).lower()
+            in ("true", "1", "yes", "delete")
             else "Retain"
         ),
         # Tag values must be quoted strings, not bare YAML booleans.
-        "REGSUB_ENFORCE_BUDGET": '"' + (
+        "REGSUB_ENFORCE_BUDGET": '"'
+        + (
             _resolve_config_value(
                 cfg,
                 "enforce_budget",
@@ -859,7 +985,8 @@ def run_create_workflow(
                 default_fallback="true",
             )
             or "true"
-        ) + '"',
+        )
+        + '"',
         "REGSUB_AWS_ACCOUNT_ID": f"aws_profile-{aws_ctx.profile}",
         "REGSUB_ALLOCATION_STRATEGY": _resolve_config_value(
             cfg,
@@ -867,7 +994,8 @@ def run_create_workflow(
             "Spot allocation strategy",
             non_interactive=non_interactive,
             default_fallback="capacity-optimized",
-        ) or "capacity-optimized",
+        )
+        or "capacity-optimized",
         # Tag value must be non-empty (AWS min length = 1).
         "REGSUB_DAYLILY_GIT_DEETS": "none",
         "REGSUB_MAX_COUNT_8I": str(max_8i),
@@ -879,18 +1007,20 @@ def run_create_workflow(
             "Headnode instance type",
             non_interactive=non_interactive,
             default_fallback="m5.xlarge",
-        ) or "m5.xlarge",
+        )
+        or "m5.xlarge",
         "REGSUB_HEARTBEAT_EMAIL": post_create_inputs.heartbeat_email,
         "REGSUB_HEARTBEAT_SCHEDULE": post_create_inputs.heartbeat_schedule,
-        "REGSUB_HEARTBEAT_SCHEDULER_ROLE_ARN": (
-            post_create_inputs.heartbeat_scheduler_role_arn
-        ),
+        "REGSUB_HEARTBEAT_SCHEDULER_ROLE_ARN": (post_create_inputs.heartbeat_scheduler_role_arn),
     }
 
     ui.step("Rendering YAML template ...")
     try:
         _yaml_init, init_template_path = write_init_artifacts(
-            cluster_name, ts, template_yaml, substitutions,
+            cluster_name,
+            ts,
+            template_yaml,
+            substitutions,
         )
     except (FileNotFoundError, ValueError) as exc:
         logger.error("YAML render failed: %s", exc)
@@ -898,9 +1028,7 @@ def run_create_workflow(
         return EXIT_VALIDATION_FAILURE
 
     # 4b. Apply spot prices
-    cluster_yaml_path = str(
-        CONFIG_DIR / f"{cluster_name}_cluster_{ts}.yaml"
-    )
+    cluster_yaml_path = str(CONFIG_DIR / f"{cluster_name}_cluster_{ts}.yaml")
     ui.step("Applying spot prices ...")
     try:
         apply_spot_prices(
@@ -921,7 +1049,9 @@ def run_create_workflow(
     ui.phase("DRY-RUN VALIDATION")
     ui.step("Running pcluster dry-run ...")
     dry_result = dry_run_create(
-        cluster_name, cluster_yaml_path, aws_ctx.region,
+        cluster_name,
+        cluster_yaml_path,
+        aws_ctx.region,
         profile=aws_ctx.profile,
     )
     if not dry_result.success:
@@ -939,7 +1069,9 @@ def run_create_workflow(
     ui.phase("CREATE CLUSTER")
     ui.step(f"Submitting cluster creation: {cluster_name} ...")
     create_result = pcluster_create(
-        cluster_name, cluster_yaml_path, aws_ctx.region,
+        cluster_name,
+        cluster_yaml_path,
+        aws_ctx.region,
         profile=aws_ctx.profile,
     )
     if not create_result.success:
@@ -956,7 +1088,9 @@ def run_create_workflow(
     ui.phase("MONITOR")
     ui.step("Waiting for CREATE_COMPLETE ...")
     monitor_result = wait_for_creation(
-        cluster_name, aws_ctx.region, profile=aws_ctx.profile,
+        cluster_name,
+        aws_ctx.region,
+        profile=aws_ctx.profile,
     )
     if not monitor_result.success:
         logger.error(
@@ -1019,7 +1153,9 @@ def run_create_workflow(
     ui.step("Ensuring budgets ...")
     try:
         global_budget = ensure_global_budget(
-            budgets_client, s3_client, aws_ctx.account_id,
+            budgets_client,
+            s3_client,
+            aws_ctx.account_id,
             amount=post_create_inputs.global_budget_amount,
             cluster_name=cluster_name,
             email=post_create_inputs.budget_email,
@@ -1029,7 +1165,9 @@ def run_create_workflow(
             allowed_users=post_create_inputs.allowed_budget_users,
         )
         cluster_budget = ensure_cluster_budget(
-            budgets_client, s3_client, aws_ctx.account_id,
+            budgets_client,
+            s3_client,
+            aws_ctx.account_id,
             amount=post_create_inputs.budget_amount,
             cluster_name=cluster_name,
             email=post_create_inputs.budget_email,
@@ -1059,7 +1197,8 @@ def run_create_workflow(
         sns_client = aws_ctx.client("sns")
         scheduler_client = aws_ctx.client("scheduler")
         hb_result = ensure_heartbeat(
-            sns_client, scheduler_client,
+            sns_client,
+            scheduler_client,
             cluster_name=cluster_name,
             region=aws_ctx.region,
             account_id=aws_ctx.account_id,
@@ -1097,9 +1236,7 @@ def run_create_workflow(
         "allowed_budget_users": post_create_inputs.allowed_budget_users,
         "heartbeat_email": post_create_inputs.heartbeat_email,
         "heartbeat_schedule": post_create_inputs.heartbeat_schedule,
-        "heartbeat_scheduler_role_arn": (
-            post_create_inputs.heartbeat_scheduler_role_arn
-        ),
+        "heartbeat_scheduler_role_arn": (post_create_inputs.heartbeat_scheduler_role_arn),
     }
     next_run_path = CONFIG_DIR / f"{cluster_name}_next_run_{ts}.yaml"
     write_next_run_template(cfg, final_values, next_run_path)
@@ -1300,9 +1437,9 @@ def configure_headnode(
                 f"cd ~/projects/{repo_name} && "
                 "bash -lc '"
                 "set -euo pipefail; "
-                "test \"$(whoami)\" = ubuntu; "
-                "test \"${DAYLILY_EC_HEADNODE_BOOTSTRAPPED:-0}\" = 1; "
-                "test \"${CONDA_DEFAULT_ENV:-}\" = DAY-EC; "
+                'test "$(whoami)" = ubuntu; '
+                'test "${DAYLILY_EC_HEADNODE_BOOTSTRAPPED:-0}" = 1; '
+                'test "${CONDA_DEFAULT_ENV:-}" = DAY-EC; '
                 "command -v daylily-ec >/dev/null 2>&1; "
                 "command -v day-clone >/dev/null 2>&1; "
                 "day-clone --list >/dev/null'"
@@ -1393,6 +1530,7 @@ def run_preflight_only(
 
     preflight_steps: List[PreflightStep] = [
         make_iam_preflight_step(aws_ctx, interactive=not non_interactive),
+        make_repository_catalog_preflight_step(),
         make_quota_preflight_step(
             aws_ctx,
             max_count_8i=max_8i,
@@ -1411,7 +1549,9 @@ def run_preflight_only(
     ]
 
     report = run_preflight(
-        report, pass_on_warn=pass_on_warn, steps=preflight_steps,
+        report,
+        pass_on_warn=pass_on_warn,
+        steps=preflight_steps,
     )
 
     # Always write the report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
     "typer>=0.12,<1",
-    "cli-core-yo==2.1.0",
+    "cli-core-yo==2.1.1",
     # aws-parallelcluster 3.13.x still imports pkg_resources at runtime.
     "setuptools<81",
     # Used by legacy bin/*.py tools (installed via setup.py script_files).

--- a/tests/test_day_clone.py
+++ b/tests/test_day_clone.py
@@ -34,7 +34,9 @@ def _write_configs(
         f"daylily:\n  analysis_root: {clone_root}\n",
         encoding="utf-8",
     )
-    ssh_line = "    ssh_url: git@github.com:Daylily-Informatics/test-repo.git\n" if include_ssh_url else ""
+    ssh_line = (
+        "    ssh_url: git@github.com:Daylily-Informatics/test-repo.git\n" if include_ssh_url else ""
+    )
     available_repos = config_dir / "daylily_available_repositories.yaml"
     available_repos.write_text(
         "default_repository: test-repo\n"
@@ -143,8 +145,70 @@ def test_day_clone_requires_explicit_default_repository(monkeypatch, tmp_path, c
     assert "Missing default_repository" in capsys.readouterr().err
 
 
+def test_day_clone_list_accepts_real_repository_catalog(monkeypatch, tmp_path, capsys):
+    module = _load_day_clone()
+    global_config, available_repos, _clone_root = _write_configs(tmp_path)
+    available_repos.write_text(
+        (REPO_ROOT / "config" / "daylily_available_repositories.yaml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    _patch_day_clone_paths(module, global_config, available_repos, monkeypatch)
+
+    rc = module.main(["--list"])
+
+    out = capsys.readouterr()
+    assert rc == 0
+    assert "daylily-omics-analysis" in out.out
+    assert "Error:" not in out.err
+
+
+def test_day_clone_list_accepts_list_valued_command_metadata(monkeypatch, tmp_path, capsys):
+    module = _load_day_clone()
+    global_config, available_repos, _clone_root = _write_configs(tmp_path)
+    available_repos.write_text(
+        "command_catalog_version: 1\n"
+        "default_repository: test-repo\n"
+        "repositories:\n"
+        "  test-repo:\n"
+        "    display_name: Test Repo\n"
+        "    https_url: https://github.com/Daylily-Informatics/test-repo.git\n"
+        "    default_ref: main\n"
+        "    relative_path: test-repo\n"
+        "    analysis_commands:\n"
+        "      - command_id: sample_command\n"
+        "        targets:\n"
+        "          - produce_alignstats\n",
+        encoding="utf-8",
+    )
+    _patch_day_clone_paths(module, global_config, available_repos, monkeypatch)
+
+    rc = module.main(["--list"])
+
+    assert rc == 0
+    assert "test-repo: Test Repo" in capsys.readouterr().out
+
+
+def test_day_clone_invalid_available_repositories_yaml_exits_2(monkeypatch, tmp_path, capsys):
+    module = _load_day_clone()
+    global_config, available_repos, _clone_root = _write_configs(tmp_path)
+    available_repos.write_text(
+        "default_repository: [unterminated\n",
+        encoding="utf-8",
+    )
+    _patch_day_clone_paths(module, global_config, available_repos, monkeypatch)
+
+    rc = module.main(["--list"])
+
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "Invalid YAML" in err
+    assert str(available_repos) in err
+
+
 def test_packaged_day_clone_matches_source_day_clone():
     source = REPO_ROOT / "bin" / "headnode_utils" / "day-clone"
-    packaged = REPO_ROOT / "daylily_ec" / "resources" / "payload" / "bin" / "headnode_utils" / "day-clone"
+    packaged = (
+        REPO_ROOT / "daylily_ec" / "resources" / "payload" / "bin" / "headnode_utils" / "day-clone"
+    )
 
     assert packaged.read_text(encoding="utf-8") == source.read_text(encoding="utf-8")

--- a/tests/test_headnode_init.py
+++ b/tests/test_headnode_init.py
@@ -50,7 +50,9 @@ def _write_executable(path: Path, content: str) -> None:
     path.chmod(0o755)
 
 
-def test_collect_headnode_state_reads_project_budget_and_bucket(monkeypatch, tmp_path: Path) -> None:
+def test_collect_headnode_state_reads_project_budget_and_bucket(
+    monkeypatch, tmp_path: Path
+) -> None:
     cfnconfig_path = tmp_path / "cfnconfig"
     cfnconfig_path.write_text("cfn_region=us-west-2\n", encoding="utf-8")
 
@@ -187,7 +189,9 @@ def test_build_shell_code_exports_expected_compatibility_helpers(monkeypatch) ->
     )
 
     assert "export DAYLILY_EC_REPO_ROOT=/repo/dayec" in shell_code
-    assert 'export DAY_CONTACT_EMAIL="${DAY_CONTACT_EMAIL:-john@daylilyinformatics.com}"' in shell_code
+    assert (
+        'export DAY_CONTACT_EMAIL="${DAY_CONTACT_EMAIL:-john@daylilyinformatics.com}"' in shell_code
+    )
     assert "export DAY_PROJECT=da-us-west-2b-demo" in shell_code
     assert "export DAY_AWS_REGION=us-west-2" in shell_code
     assert 'export DAY_ROOT="${PWD}"' in shell_code
@@ -218,9 +222,7 @@ def test_run_headnode_init_emit_shell_non_interactive_sends_warnings_to_stderr(
     assert "Warning: Budget tags file not found." in captured.err
 
 
-def test_run_headnode_init_interactive_mode_prompts_for_missing_budget(
-    monkeypatch, capsys
-) -> None:
+def test_run_headnode_init_interactive_mode_prompts_for_missing_budget(monkeypatch, capsys) -> None:
     state = headnode.HeadnodeState(
         region="us-west-2",
         project="da-us-west-2b-demo",
@@ -300,7 +302,9 @@ def test_install_headnode_tools_writes_idempotent_login_bootstrap_block(tmp_path
     ):
         path.mkdir(parents=True, exist_ok=True)
 
-    (resources_dir / "config" / "daylily_cli_global.yaml").write_text("daylily: {}\n", encoding="utf-8")
+    (resources_dir / "config" / "daylily_cli_global.yaml").write_text(
+        "daylily: {}\n", encoding="utf-8"
+    )
     (resources_dir / "config" / "daylily_available_repositories.yaml").write_text(
         "default_repository: daylily-omics-analysis\nrepositories: {}\n",
         encoding="utf-8",
@@ -310,7 +314,10 @@ def test_install_headnode_tools_writes_idempotent_login_bootstrap_block(tmp_path
         encoding="utf-8",
     )
     cluster_config_path = tmp_path / "cluster-config.yaml"
-    cluster_config_path.write_text("HeadNode:\n  CustomActions:\n    OnNodeConfigured:\n      Script: s3://reference-bucket/bootstrap.sh\n", encoding="utf-8")
+    cluster_config_path.write_text(
+        "HeadNode:\n  CustomActions:\n    OnNodeConfigured:\n      Script: s3://reference-bucket/bootstrap.sh\n",
+        encoding="utf-8",
+    )
 
     _write_executable(
         resources_dir / "bin" / "headnode_utils" / "day-clone",
@@ -324,9 +331,9 @@ def test_install_headnode_tools_writes_idempotent_login_bootstrap_block(tmp_path
         checkout_dir / "activate",
         (
             "#!/usr/bin/env bash\n"
-            "export PATH=\"${FAKE_DAYLILY_BIN}:$PATH\"\n"
-            "export DAYLILY_EC_REPO_ROOT=\"${DAYLILY_EC_RESOURCES_DIR}\"\n"
-            "export CONDA_DEFAULT_ENV=\"DAY-EC\"\n"
+            'export PATH="${FAKE_DAYLILY_BIN}:$PATH"\n'
+            'export DAYLILY_EC_REPO_ROOT="${DAYLILY_EC_RESOURCES_DIR}"\n'
+            'export CONDA_DEFAULT_ENV="DAY-EC"\n'
             "printf 'activate\\n' >>\"${HEADNODE_TEST_LOG}\"\n"
         ),
     )
@@ -334,12 +341,12 @@ def test_install_headnode_tools_writes_idempotent_login_bootstrap_block(tmp_path
         fake_bin / "daylily-ec",
         (
             "#!/usr/bin/env bash\n"
-            "printf 'daylily-ec:%s\\n' \"$*\" >>\"${HEADNODE_TEST_LOG}\"\n"
-            "if [[ \"$1\" == \"headnode\" && \"$2\" == \"init\" && \"$3\" == \"--emit-shell\" && \"$4\" == \"--non-interactive\" && \"$5\" == \"--skip-project-check\" ]]; then\n"
+            'printf \'daylily-ec:%s\\n\' "$*" >>"${HEADNODE_TEST_LOG}"\n'
+            'if [[ "$1" == "headnode" && "$2" == "init" && "$3" == "--emit-shell" && "$4" == "--non-interactive" && "$5" == "--skip-project-check" ]]; then\n'
             "  printf '%s\\n' 'export TEST_HEADNODE_BOOTSTRAP=1'\n"
             "  exit 0\n"
             "fi\n"
-            "if [[ \"$1\" == \"resources-dir\" ]]; then\n"
+            'if [[ "$1" == "resources-dir" ]]; then\n'
             "  printf '%s\\n' \"${DAYLILY_EC_RESOURCES_DIR}\"\n"
             "  exit 0\n"
             "fi\n"
@@ -350,20 +357,16 @@ def test_install_headnode_tools_writes_idempotent_login_bootstrap_block(tmp_path
     legacy_block = (
         "# >>> daylily headnode bootstrap >>>\n"
         "daylily_headnode_bootstrap() {\n"
-        "    local repo_root=\"$HOME/projects/daylily-ephemeral-cluster\"\n"
-        "    local activate_script=\"$repo_root/activate\"\n"
+        '    local repo_root="$HOME/projects/daylily-ephemeral-cluster"\n'
+        '    local activate_script="$repo_root/activate"\n'
         "    export DAYLILY_EC_HEADNODE_BOOTSTRAPPED=1\n"
-        "    source \"$activate_script\"\n"
+        '    source "$activate_script"\n'
         "}\n"
         "daylily_headnode_bootstrap\n"
         "unset -f daylily_headnode_bootstrap\n"
         "# <<< daylily headnode bootstrap <<<\n"
     )
-    conda_block = (
-        "# >>> conda initialize >>>\n"
-        "conda hook\n"
-        "# <<< conda initialize <<<\n"
-    )
+    conda_block = "# >>> conda initialize >>>\nconda hook\n# <<< conda initialize <<<\n"
     (home_dir / ".bashrc").write_text(legacy_block + "\n" + conda_block, encoding="utf-8")
     (home_dir / ".bash_profile").write_text(legacy_block + "\n" + conda_block, encoding="utf-8")
 
@@ -398,9 +401,11 @@ def test_install_headnode_tools_writes_idempotent_login_bootstrap_block(tmp_path
 
     assert bashrc.count("# >>> daylily headnode bootstrap >>>") == 1
     assert bash_profile.count("# >>> daylily headnode bootstrap >>>") == 1
-    assert 'daylily-headnode-bootstrap.sh' in bashrc
-    assert 'daylily-headnode-bootstrap.sh' in bash_profile
-    assert bashrc.index("# >>> conda initialize >>>") < bashrc.index("# >>> daylily headnode bootstrap >>>")
+    assert "daylily-headnode-bootstrap.sh" in bashrc
+    assert "daylily-headnode-bootstrap.sh" in bash_profile
+    assert bashrc.index("# >>> conda initialize >>>") < bashrc.index(
+        "# >>> daylily headnode bootstrap >>>"
+    )
     assert bash_profile.index("# >>> conda initialize >>>") < bash_profile.index(
         "# >>> daylily headnode bootstrap >>>"
     )
@@ -408,16 +413,24 @@ def test_install_headnode_tools_writes_idempotent_login_bootstrap_block(tmp_path
     bootstrap_text = bootstrap_file.read_text(encoding="utf-8")
     assert 'repo_root="$HOME/projects/daylily-ephemeral-cluster"' in bootstrap_text
     assert 'case ":$PATH:" in' in bootstrap_text
-    assert 'DAYLILY_EC_HEADNODE_BOOTSTRAPPED' in bootstrap_text
+    assert "DAYLILY_EC_HEADNODE_BOOTSTRAPPED" in bootstrap_text
     assert 'source "$activate_script"' in bootstrap_text
-    assert 'conda activate DAY-EC' in bootstrap_text
-    assert 'eval "$(daylily-ec headnode init --emit-shell --non-interactive --skip-project-check)"' in bootstrap_text
+    assert "conda activate DAY-EC" in bootstrap_text
+    assert (
+        'eval "$(daylily-ec headnode init --emit-shell --non-interactive --skip-project-check)"'
+        in bootstrap_text
+    )
     assert "daylily_headnode_bootstrap()" not in bootstrap_text
     assert "unset -f daylily_headnode_bootstrap" not in bootstrap_text
     assert (user_bin_dir / "day-clone").is_file()
     assert log_text.count("install_miniconda") >= 2
     assert log_text.count("activate") == 2
-    assert log_text.count("daylily-ec:headnode init --emit-shell --non-interactive --skip-project-check") == 2
+    assert (
+        log_text.count(
+            "daylily-ec:headnode init --emit-shell --non-interactive --skip-project-check"
+        )
+        == 2
+    )
 
 
 def test_install_headnode_tools_fails_when_miniconda_install_fails(tmp_path: Path) -> None:
@@ -434,7 +447,9 @@ def test_install_headnode_tools_fails_when_miniconda_install_fails(tmp_path: Pat
     ):
         path.mkdir(parents=True, exist_ok=True)
 
-    (resources_dir / "config" / "daylily_cli_global.yaml").write_text("daylily: {}\n", encoding="utf-8")
+    (resources_dir / "config" / "daylily_cli_global.yaml").write_text(
+        "daylily: {}\n", encoding="utf-8"
+    )
     (resources_dir / "config" / "daylily_available_repositories.yaml").write_text(
         "default_repository: daylily-omics-analysis\nrepositories: {}\n",
         encoding="utf-8",
@@ -444,7 +459,10 @@ def test_install_headnode_tools_fails_when_miniconda_install_fails(tmp_path: Pat
         encoding="utf-8",
     )
     cluster_config_path = tmp_path / "cluster-config.yaml"
-    cluster_config_path.write_text("HeadNode:\n  CustomActions:\n    OnNodeConfigured:\n      Script: s3://reference-bucket/bootstrap.sh\n", encoding="utf-8")
+    cluster_config_path.write_text(
+        "HeadNode:\n  CustomActions:\n    OnNodeConfigured:\n      Script: s3://reference-bucket/bootstrap.sh\n",
+        encoding="utf-8",
+    )
 
     _write_executable(
         resources_dir / "bin" / "headnode_utils" / "day-clone",
@@ -456,7 +474,7 @@ def test_install_headnode_tools_fails_when_miniconda_install_fails(tmp_path: Pat
     )
     _write_executable(
         resources_dir / "activate",
-        "#!/usr/bin/env bash\nexport CONDA_DEFAULT_ENV=\"DAY-EC\"\n",
+        '#!/usr/bin/env bash\nexport CONDA_DEFAULT_ENV="DAY-EC"\n',
     )
     _write_executable(
         fake_bin / "daylily-ec",
@@ -503,3 +521,48 @@ def test_active_runtime_paths_no_longer_invoke_dyinit() -> None:
         text = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
         assert "source dyinit" not in text
         assert ". dyinit" not in text
+
+
+def test_post_install_bootstrap_logs_and_fails_hard_for_missing_apptainer() -> None:
+    script = (REPO_ROOT / "config/day_cluster/post_install_ubuntu_combined.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "set -Ee -o pipefail" in script
+    assert "set -Eeuo pipefail" not in script
+    assert 'export HOME="${HOME:-/root}"' in script
+    assert "trap 'rc=$?; echo \"[$(date +%Y%m%d_%H%M%S)] ERROR rc=${rc}" in script
+    assert 'exec > >(tee -a "${local_log_fn}" "${fsx_log_fn}") 2>&1' in script
+    assert "apptainer_1.4.5_amd64.deb" in script
+    assert "70f19af846501acfbc2e42e7cfeee9ee11ddbbfa1c3502d0d99cde34e8e0af05" in script
+    assert "cached Apptainer deb not found" in script
+    assert 'apt-get install -y "${apptainer_deb}"' in script
+    assert 'ln -sfn "$(command -v apptainer)" /usr/local/bin/singularity' in script
+    assert "ln -sfn /fsx/data/tool_specific_resources/cromwell_87.jar" in script
+    assert "ln -sfn /fsx/data/tool_specific_resources/womtool_87.jar" in script
+    assert "link_cached_entries /fsx/data/cached_envs/conda" in script
+    assert "required" in script
+    assert "optional" in script
+    assert "No optional cached entries found under" in script
+    assert "Cached entry already present, leaving in place" in script
+    assert "Original sbatch already present" in script
+    assert "Original srun already present" in script
+    assert "ln -sfn /opt/slurm/bin/sbatch /opt/slurm/bin/srun" in script
+    assert 'append_once "PrologFlags=Alloc" /opt/slurm/etc/slurm.conf' in script
+    assert "mv /opt/slurm/bin/sbatch /opt/slurm/sbin/sbatch" in script
+    assert "mv /opt/slurm/bin/srun /opt/slurm/sbin/srun" in script
+    assert "ln -s /fsx/data/cached_envs/conda/*" not in script
+    assert 'echo "PrologFlags=Alloc" >> /opt/slurm/etc/slurm.conf' not in script
+    assert "ppa:apptainer/ppa" not in script
+    assert "command -v apptainer" in script
+    assert "command -v singularity" in script
+
+
+def test_packaged_post_install_bootstrap_matches_source() -> None:
+    source = REPO_ROOT / "config/day_cluster/post_install_ubuntu_combined.sh"
+    packaged = (
+        REPO_ROOT
+        / "daylily_ec/resources/payload/config/day_cluster/post_install_ubuntu_combined.sh"
+    )
+
+    assert packaged.read_text(encoding="utf-8") == source.read_text(encoding="utf-8")

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -48,6 +48,8 @@ from daylily_ec.workflow.create_cluster import (
     _require_values,
     _resolve_config_value,
     configure_headnode,
+    make_repository_catalog_preflight_step,
+    run_preflight,
 )
 
 
@@ -125,6 +127,68 @@ class TestNoopHeartbeatResult:
         assert result.error == "skipped"
 
 
+class TestRepositoryCatalogPreflight:
+    def test_valid_checked_in_catalog_passes(self):
+        catalog_path = (
+            Path(__file__).resolve().parents[1] / "config" / ("daylily_available_repositories.yaml")
+        )
+        report = PreflightReport()
+
+        result = make_repository_catalog_preflight_step(catalog_path)(report)
+
+        check = result.checks[-1]
+        assert check.id == "config.repository_catalog"
+        assert check.status == CheckStatus.PASS
+        assert check.details["path"] == str(catalog_path)
+        assert check.details["repository_count"] >= 1
+        assert check.details["command_count"] >= 1
+
+    def test_malformed_catalog_fails_with_headnode_day_clone_context(self, tmp_path):
+        catalog_path = tmp_path / "daylily_available_repositories.yaml"
+        catalog_path.write_text(
+            "command_catalog_version: [unterminated\n",
+            encoding="utf-8",
+        )
+        report = PreflightReport()
+
+        result = make_repository_catalog_preflight_step(catalog_path)(report)
+
+        check = result.checks[-1]
+        assert check.id == "config.repository_catalog"
+        assert check.status == CheckStatus.FAIL
+        assert check.details["path"] == str(catalog_path)
+        assert "while parsing a flow sequence" in check.details["error"]
+        assert "Headnode configuration would fail" in check.remediation
+        assert "day-clone consumes this file" in check.remediation
+
+    def test_malformed_catalog_short_circuits_preflight_pipeline(self, monkeypatch, tmp_path):
+        catalog_path = tmp_path / "daylily_available_repositories.yaml"
+        catalog_path.write_text(
+            "command_catalog_version: [unterminated\n",
+            encoding="utf-8",
+        )
+        called = False
+
+        def later_step(report: PreflightReport) -> PreflightReport:
+            nonlocal called
+            called = True
+            return report
+
+        monkeypatch.setattr(
+            create_cluster_module,
+            "write_preflight_report",
+            lambda report: None,
+        )
+
+        result = run_preflight(
+            PreflightReport(),
+            steps=[make_repository_catalog_preflight_step(catalog_path), later_step],
+        )
+
+        assert called is False
+        assert result.failed_checks[0].id == "config.repository_catalog"
+
+
 class TestWorkflowResolutionHelpers:
     def test_resolve_config_value_uses_default_non_interactive(self):
         cfg = ConfigFile.model_validate(
@@ -169,9 +233,7 @@ class TestWorkflowResolutionHelpers:
         mock_prompt.assert_called_once()
 
     def test_require_values_reports_missing_labels(self):
-        msg = _require_values(
-            {"bucket": "b", "public subnet": "", "IAM policy ARN": ""}
-        )
+        msg = _require_values({"bucket": "b", "public subnet": "", "IAM policy ARN": ""})
         assert msg == "Missing required values: public subnet, IAM policy ARN"
 
     def test_build_connection_command_uses_ssm_helper(self):
@@ -229,7 +291,9 @@ class TestWorkflowResolutionHelpers:
         )
 
         with (
-            patch("daylily_ec.workflow.create_cluster.typer.prompt", return_value="2") as mock_prompt,
+            patch(
+                "daylily_ec.workflow.create_cluster.typer.prompt", return_value="2"
+            ) as mock_prompt,
             patch("daylily_ec.workflow.create_cluster.typer.echo") as mock_echo,
         ):
             assert _resolve_fsx_size(cfg, non_interactive=False) == "2400"
@@ -258,7 +322,9 @@ class TestWorkflowResolutionHelpers:
         )
 
         with (
-            patch("daylily_ec.workflow.create_cluster.typer.prompt", return_value="9600") as mock_prompt,
+            patch(
+                "daylily_ec.workflow.create_cluster.typer.prompt", return_value="9600"
+            ) as mock_prompt,
             patch("daylily_ec.workflow.create_cluster.typer.echo"),
         ):
             assert _resolve_fsx_size(cfg, non_interactive=False) == "9600"
@@ -318,9 +384,7 @@ class TestRunCreateWorkflow:
         rc = run_create_workflow("us-west-2b", profile="test", non_interactive=True)
         assert rc == EXIT_AWS_FAILURE
 
-    def test_collects_budget_and_heartbeat_inputs_before_dry_run(
-        self, tmp_path, monkeypatch
-    ):
+    def test_collects_budget_and_heartbeat_inputs_before_dry_run(self, tmp_path, monkeypatch):
         records = _run_stubbed_create_workflow(
             tmp_path,
             monkeypatch,
@@ -355,18 +419,14 @@ class TestRunCreateWorkflow:
         assert records["global_budget_kwargs"]["allowed_users"] == "root"
         assert records["cluster_budget_kwargs"]["email"] == "johnm@lsmc.com"
         assert records["heartbeat_kwargs"]["email"] == "johnm@lsmc.com"
-        assert (
-            records["heartbeat_kwargs"]["schedule_expression"] == "rate(60 minutes)"
-        )
+        assert records["heartbeat_kwargs"]["schedule_expression"] == "rate(60 minutes)"
         assert records["next_run_values"]["budget_email"] == "johnm@lsmc.com"
         assert records["next_run_values"]["heartbeat_email"] == "johnm@lsmc.com"
         assert records["next_run_values"]["heartbeat_schedule"] == "rate(60 minutes)"
         assert records["next_run_values"]["heartbeat_scheduler_role_arn"] == ""
         assert records["resolve_scheduler_role_kwargs"]["preconfigured"] == ""
 
-    def test_prints_ssh_command_then_fin_and_runs_say_when_available(
-        self, tmp_path, monkeypatch
-    ):
+    def test_prints_ssh_command_then_fin_and_runs_say_when_available(self, tmp_path, monkeypatch):
         records = _run_stubbed_create_workflow(
             tmp_path,
             monkeypatch,
@@ -401,10 +461,7 @@ class TestRunCreateWorkflow:
             "daylily-ssh-into-headnode --profile lsmc --region us-west-2 --cluster majors-cluster",
             "...fin!",
         ]
-        assert records["subprocess_calls"] == [
-            ["/bin/sh", "-lc", "command -v say >/dev/null 2>&1"]
-        ]
-
+        assert records["subprocess_calls"] == [["/bin/sh", "-lc", "command -v say >/dev/null 2>&1"]]
 
 
 # ── configure_headnode ───────────────────────────────────────────────
@@ -445,7 +502,10 @@ class TestConfigureHeadnode:
         assert "conda tos accept --override-channels" in tos_cmd
         assert "https://repo.anaconda.com/pkgs/main" in tos_cmd
         assert "https://repo.anaconda.com/pkgs/r" in tos_cmd
-        assert "source ~/projects/daylily-ephemeral-cluster/activate" in mock_run_shell.call_args_list[3].args[2]
+        assert (
+            "source ~/projects/daylily-ephemeral-cluster/activate"
+            in mock_run_shell.call_args_list[3].args[2]
+        )
         assert "bash -lc" in mock_run_shell.call_args_list[4].args[2]
         assert "whoami" in mock_run_shell.call_args_list[4].args[2]
         mock_write_remote_text.assert_not_called()
@@ -524,7 +584,9 @@ class TestConfigureHeadnode:
 
     @patch("daylily_ec.aws.ssm.write_remote_text")
     @patch("daylily_ec.aws.ssm.run_shell")
-    def test_step_failure_is_fatal(self, mock_run_shell, mock_write_remote_text, tmp_path, monkeypatch):
+    def test_step_failure_is_fatal(
+        self, mock_run_shell, mock_write_remote_text, tmp_path, monkeypatch
+    ):
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.chdir(tmp_path)
         monkeypatch.delenv("DAYLILY_EC_REPO_ROOT", raising=False)
@@ -605,8 +667,14 @@ class TestConfigureHeadnode:
         monkeypatch.chdir(tmp_path)
         monkeypatch.delenv("DAYLILY_EC_REPO_ROOT", raising=False)
         (tmp_path / "config").mkdir()
-        (tmp_path / "config" / "daylily_cli_global.yaml").write_text("daylily: {}\n", encoding="utf-8")
-        monkeypatch.setattr(resources_module, "resource_path", lambda _rel: tmp_path / "missing_available_repositories.yaml")
+        (tmp_path / "config" / "daylily_cli_global.yaml").write_text(
+            "daylily: {}\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(
+            resources_module,
+            "resource_path",
+            lambda _rel: tmp_path / "missing_available_repositories.yaml",
+        )
 
         mock_run_shell.side_effect = [
             SimpleNamespace(stdout="", stderr=""),
@@ -789,7 +857,9 @@ class TestConfigureHeadnode:
 
         def fake_git_run(cmd, **_kwargs):
             if cmd == ["git", "-C", str(repo_root), "config", "--get", "remote.origin.url"]:
-                return subprocess.CompletedProcess(cmd, 0, "git@gitlab.example.com:org/repo.git\n", "")
+                return subprocess.CompletedProcess(
+                    cmd, 0, "git@gitlab.example.com:org/repo.git\n", ""
+                )
             raise AssertionError(f"unexpected subprocess.run call: {cmd}")
 
         mock_subprocess_run.side_effect = fake_git_run
@@ -1053,9 +1123,7 @@ def _run_stubbed_create_workflow(
             policy_arn="arn:policy:default",
         ),
     )
-    monkeypatch.setattr(
-        cloudformation, "derive_stack_name", lambda _region_az: "daylily-stack"
-    )
+    monkeypatch.setattr(cloudformation, "derive_stack_name", lambda _region_az: "daylily-stack")
     monkeypatch.setattr(aws_ec2, "list_public_subnets", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(aws_ec2, "list_private_subnets", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(
@@ -1111,9 +1179,7 @@ def _run_stubbed_create_workflow(
     monkeypatch.setattr(create_cluster_module.typer, "prompt", fake_prompt)
     monkeypatch.setattr(create_cluster_module.typer, "echo", fake_echo)
     monkeypatch.setattr(create_cluster_module.subprocess, "run", fake_subprocess_run)
-    monkeypatch.setattr(
-        triplets, "write_next_run_template", fake_write_next_run_template
-    )
+    monkeypatch.setattr(triplets, "write_next_run_template", fake_write_next_run_template)
     monkeypatch.setattr(
         state_store,
         "write_state_record",


### PR DESCRIPTION
## Summary
- update `day-clone` to parse the repository catalog as real YAML, including list-valued command metadata
- add cluster creation preflight validation for malformed repository catalogs
- harden the Ubuntu bootstrap script for reruns, cached Apptainer installs, and existing copied artifacts
- point cluster creation at daylily-ec `2.1.13`

## Validation
- targeted tests were run during implementation for `day-clone`, repository catalog validation, headnode init, and workflow behavior
- live checks verified Apptainer/Singularity availability and bootstrap logging on a new headnode
