### PR TITLE
Fix headnode connect terminal flow control

### DIFF
--- a/bin/install-daylily-headnode-tools
+++ b/bin/install-daylily-headnode-tools
@@ -49,6 +49,8 @@ repo_root="$HOME/projects/daylily-ephemeral-cluster"
 activate_script="$repo_root/activate"
 user_bin_dir="$HOME/.local/bin"
 
+stty -ixon -ixoff 2>/dev/null || true
+
 case ":$PATH:" in
     *":${user_bin_dir}:"*) ;;
     *) export PATH="${user_bin_dir}:$PATH" ;;

--- a/config/daylily_available_repositories.yaml
+++ b/config/daylily_available_repositories.yaml
@@ -7,7 +7,7 @@ repositories:
     description: "Primary whole genome and multiomics workflows."
     https_url: https://github.com/Daylily-Informatics/daylily-omics-analysis.git
     ssh_url: git@github.com:Daylily-Informatics/daylily-omics-analysis.git
-    default_ref: 0.7.713
+    default_ref: 0.7.714
     relative_path: daylily-omics-analysis
     analysis_commands:
       - command_id: illumina_snv_alignstats

--- a/daylily_ec/aws/ssm.py
+++ b/daylily_ec/aws/ssm.py
@@ -23,7 +23,9 @@ PENDING_STATUSES = {"Pending", "InProgress", "Delayed"}
 SUCCESS_STATUS = "Success"
 SUPPORTED_REMOTE_USER = "ubuntu"
 SUPPORTED_SESSION_HOME = f"/home/{SUPPORTED_REMOTE_USER}"
-SUPPORTED_SESSION_SHELL_PROFILE = f"cd {SUPPORTED_SESSION_HOME} && exec bash -l"
+SUPPORTED_SESSION_SHELL_PROFILE = (
+    f"cd {SUPPORTED_SESSION_HOME} && {{ stty -ixon -ixoff 2>/dev/null || true; exec bash -l; }}"
+)
 
 
 class SsmError(RuntimeError):
@@ -466,6 +468,23 @@ def ensure_ubuntu_session_preferences(
     _require_ubuntu_session_preferences(region, profile=profile)
 
 
+def _disable_local_software_flow_control() -> None:
+    """Let interactive tools receive Ctrl-S/Ctrl-Q through the local terminal."""
+    if not os.isatty(0):
+        return
+    try:
+        result = subprocess.run(
+            ["stty", "-ixon", "-ixoff"],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise SsmError("stty not found on PATH; unable to prepare local terminal.") from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "unknown error"
+        raise SsmError(f"Unable to disable local terminal software flow control: {detail}")
+
+
 def start_session(
     instance_id: str,
     region: str,
@@ -476,6 +495,7 @@ def start_session(
     """Start an interactive Session Manager shell."""
     require_session_manager_plugin()
     ensure_ubuntu_session_preferences(region, profile=profile)
+    _disable_local_software_flow_control()
     cmd = [
         "aws",
         "ssm",

--- a/daylily_ec/resources/payload/bin/install-daylily-headnode-tools
+++ b/daylily_ec/resources/payload/bin/install-daylily-headnode-tools
@@ -49,6 +49,8 @@ repo_root="$HOME/projects/daylily-ephemeral-cluster"
 activate_script="$repo_root/activate"
 user_bin_dir="$HOME/.local/bin"
 
+stty -ixon -ixoff 2>/dev/null || true
+
 case ":$PATH:" in
     *":${user_bin_dir}:"*) ;;
     *) export PATH="${user_bin_dir}:$PATH" ;;

--- a/daylily_ec/resources/payload/config/daylily_available_repositories.yaml
+++ b/daylily_ec/resources/payload/config/daylily_available_repositories.yaml
@@ -7,7 +7,7 @@ repositories:
     description: "Primary whole genome and multiomics workflows."
     https_url: https://github.com/Daylily-Informatics/daylily-omics-analysis.git
     ssh_url: git@github.com:Daylily-Informatics/daylily-omics-analysis.git
-    default_ref: 0.7.713
+    default_ref: 0.7.714
     relative_path: daylily-omics-analysis
     analysis_commands:
       - command_id: illumina_snv_alignstats

--- a/daylily_ec/workflow/create_cluster.py
+++ b/daylily_ec/workflow/create_cluster.py
@@ -1435,14 +1435,15 @@ def configure_headnode(
             region,
             (
                 f"cd ~/projects/{repo_name} && "
-                "bash -lc '"
+                "script -q -c \"bash -lc '"
                 "set -euo pipefail; "
                 'test "$(whoami)" = ubuntu; '
                 'test "${DAYLILY_EC_HEADNODE_BOOTSTRAPPED:-0}" = 1; '
                 'test "${CONDA_DEFAULT_ENV:-}" = DAY-EC; '
                 "command -v daylily-ec >/dev/null 2>&1; "
                 "command -v day-clone >/dev/null 2>&1; "
-                "day-clone --list >/dev/null'"
+                'stty -a 2>/dev/null | grep -Eq \\"(^|[[:space:];])-ixon([[:space:];]|$)\\"; '
+                "day-clone --list >/dev/null'\" /dev/null"
             ),
             profile=profile,
             timeout=None,

--- a/docs/aws_setup.md
+++ b/docs/aws_setup.md
@@ -82,15 +82,18 @@ The repo hard-fails unless that document is configured to:
 - set `runAsDefaultUser` to `ubuntu`
 - change directory to `/home/ubuntu` and source a login shell for `ubuntu`
   through `shellProfile.linux`
+- disable terminal software flow control before starting the login shell so
+  interactive tools receive key chords such as `Ctrl-S`
 
 The supported shell profile is:
 
 ```text
-cd /home/ubuntu && exec bash -l
+cd /home/ubuntu && { stty -ixon -ixoff 2>/dev/null || true; exec bash -l; }
 ```
 
 Equivalent forms that `cd` to the ubuntu home directory before starting the
-login shell are also accepted. A bare `exec bash -l` is not sufficient because
+login shell are also accepted. They should also disable XON/XOFF flow control
+with `stty -ixon -ixoff`. A bare `exec bash -l` is not sufficient because
 Session Manager starts in the SSM agent working directory.
 
 If this document is missing or misconfigured, `daylily-ec headnode connect` and other supported SSM flows will fail on purpose.

--- a/tests/test_headnode_init.py
+++ b/tests/test_headnode_init.py
@@ -413,6 +413,7 @@ def test_install_headnode_tools_writes_idempotent_login_bootstrap_block(tmp_path
     bootstrap_text = bootstrap_file.read_text(encoding="utf-8")
     assert 'repo_root="$HOME/projects/daylily-ephemeral-cluster"' in bootstrap_text
     assert 'case ":$PATH:" in' in bootstrap_text
+    assert "stty -ixon -ixoff 2>/dev/null || true" in bootstrap_text
     assert "DAYLILY_EC_HEADNODE_BOOTSTRAPPED" in bootstrap_text
     assert 'source "$activate_script"' in bootstrap_text
     assert "conda activate DAY-EC" in bootstrap_text
@@ -521,6 +522,13 @@ def test_active_runtime_paths_no_longer_invoke_dyinit() -> None:
         text = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
         assert "source dyinit" not in text
         assert ". dyinit" not in text
+
+
+def test_packaged_install_headnode_tools_matches_source() -> None:
+    source = REPO_ROOT / "bin/install-daylily-headnode-tools"
+    packaged = REPO_ROOT / "daylily_ec/resources/payload/bin/install-daylily-headnode-tools"
+
+    assert packaged.read_text(encoding="utf-8") == source.read_text(encoding="utf-8")
 
 
 def test_post_install_bootstrap_logs_and_fails_hard_for_missing_apptainer() -> None:

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -288,17 +288,19 @@ class TestWriteRemoteText:
 
 class TestStartSession:
     @patch("daylily_ec.aws.ssm.require_session_manager_plugin")
+    @patch("daylily_ec.aws.ssm.os.isatty", return_value=False)
     @patch("daylily_ec.aws.ssm.subprocess.run")
     def test_validates_session_manager_run_as_ubuntu_and_starts_session(
         self,
         mock_run,
+        _mock_isatty,
         _mock_require_plugin,
     ):
         mock_run.side_effect = [
             subprocess.CompletedProcess(
                 args=[],
                 returncode=0,
-                stdout='{"inputs":{"runAsEnabled":true,"runAsDefaultUser":"ubuntu","shellProfile":{"linux":"cd /home/ubuntu && exec bash -l"}}}',
+                stdout='{"inputs":{"runAsEnabled":true,"runAsDefaultUser":"ubuntu","shellProfile":{"linux":"cd /home/ubuntu && { stty -ixon -ixoff 2>/dev/null || true; exec bash -l; }"}}}',
                 stderr="",
             ),
             subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
@@ -329,10 +331,12 @@ class TestStartSession:
 
     @patch("daylily_ec.aws.ssm.require_session_manager_plugin")
     @patch("daylily_ec.aws.ssm.os.execvpe")
+    @patch("daylily_ec.aws.ssm.os.isatty", return_value=False)
     @patch("daylily_ec.aws.ssm.subprocess.run")
     def test_can_replace_process_for_interactive_sessions(
         self,
         mock_run,
+        _mock_isatty,
         mock_execvpe,
         _mock_require_plugin,
     ):
@@ -342,7 +346,7 @@ class TestStartSession:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
-            stdout='{"inputs":{"runAsEnabled":true,"runAsDefaultUser":"ubuntu","shellProfile":{"linux":"cd /home/ubuntu && exec bash -l"}}}',
+            stdout='{"inputs":{"runAsEnabled":true,"runAsDefaultUser":"ubuntu","shellProfile":{"linux":"cd /home/ubuntu && { stty -ixon -ixoff 2>/dev/null || true; exec bash -l; }"}}}',
             stderr="",
         )
         mock_execvpe.side_effect = ExecCalled()
@@ -371,6 +375,32 @@ class TestStartSession:
         ]
         assert env["AWS_PROFILE"] == "dev"
         assert env["AWS_REGION"] == "us-west-2"
+
+    @patch("daylily_ec.aws.ssm.require_session_manager_plugin")
+    @patch("daylily_ec.aws.ssm.os.isatty", return_value=True)
+    @patch("daylily_ec.aws.ssm.subprocess.run")
+    def test_disables_local_software_flow_control_before_session(
+        self,
+        mock_run,
+        _mock_isatty,
+        _mock_require_plugin,
+    ):
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout='{"inputs":{"runAsEnabled":true,"runAsDefaultUser":"ubuntu","shellProfile":{"linux":"cd /home/ubuntu && { stty -ixon -ixoff 2>/dev/null || true; exec bash -l; }"}}}',
+                stderr="",
+            ),
+            subprocess.CompletedProcess(args=["stty"], returncode=0, stdout="", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ]
+
+        rc = start_session("i-abc123", "us-west-2", profile="dev")
+
+        assert rc == 0
+        assert mock_run.call_args_list[1].args[0] == ["stty", "-ixon", "-ixoff"]
+        assert mock_run.call_args_list[2].args[0][:3] == ["aws", "ssm", "start-session"]
 
     @patch("daylily_ec.aws.ssm.require_session_manager_plugin")
     @patch("daylily_ec.aws.ssm.subprocess.run")

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -507,7 +507,10 @@ class TestConfigureHeadnode:
             in mock_run_shell.call_args_list[3].args[2]
         )
         assert "bash -lc" in mock_run_shell.call_args_list[4].args[2]
+        assert "script -q -c" in mock_run_shell.call_args_list[4].args[2]
         assert "whoami" in mock_run_shell.call_args_list[4].args[2]
+        assert "stty -a" in mock_run_shell.call_args_list[4].args[2]
+        assert "-ixon" in mock_run_shell.call_args_list[4].args[2]
         mock_write_remote_text.assert_not_called()
 
     @patch("daylily_ec.aws.ssm.write_remote_text")


### PR DESCRIPTION
## Summary
- disables local terminal XON/XOFF before Session Manager interactive sessions
- updates the supported SSM shell profile documentation/tests for ubuntu login shells in /home/ubuntu
- disables XON/XOFF inside the managed headnode login bootstrap and validates fresh login shells under a PTY

## Validation
- pytest tests/test_headnode_init.py tests/test_ssm.py tests/test_workflow.py -q
- ruff check
- ruff format --check daylily_ec/workflow/create_cluster.py tests/test_headnode_init.py tests/test_workflow.py tests/test_ssm.py
- git diff --check
- live at-sanity reconfigure succeeded and PTY login shell reported -ixon/-ixoff
