### PR TITLE
Keep local flow control disabled during SSM sessions

### DIFF
--- a/daylily_ec/aws/ssm.py
+++ b/daylily_ec/aws/ssm.py
@@ -9,6 +9,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
 import time
 from dataclasses import dataclass
 from pathlib import PurePosixPath
@@ -485,6 +486,36 @@ def _disable_local_software_flow_control() -> None:
         raise SsmError(f"Unable to disable local terminal software flow control: {detail}")
 
 
+def _start_local_software_flow_control_guard() -> subprocess.Popen[str] | None:
+    """Keep local XON/XOFF disabled while Session Manager initializes the PTY."""
+    if not os.isatty(0):
+        return None
+    script = (
+        "import os, subprocess, sys, time; "
+        "parent = int(sys.argv[1]); "
+        "cmd = ['stty', '-ixon', '-ixoff']; "
+        "devnull = subprocess.DEVNULL; "
+        "\nwhile True:\n"
+        "    try:\n"
+        "        os.kill(parent, 0)\n"
+        "    except OSError:\n"
+        "        break\n"
+        "    try:\n"
+        "        with open('/dev/tty', 'rb', buffering=0) as tty:\n"
+        "            subprocess.run(cmd, stdin=tty, stdout=devnull, stderr=devnull)\n"
+        "    except Exception:\n"
+        "        pass\n"
+        "    time.sleep(0.1)\n"
+    )
+    return subprocess.Popen(
+        [sys.executable, "-c", script, str(os.getpid())],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+
+
 def start_session(
     instance_id: str,
     region: str,
@@ -496,6 +527,7 @@ def start_session(
     require_session_manager_plugin()
     ensure_ubuntu_session_preferences(region, profile=profile)
     _disable_local_software_flow_control()
+    flow_control_guard = _start_local_software_flow_control_guard()
     cmd = [
         "aws",
         "ssm",
@@ -512,8 +544,20 @@ def start_session(
         try:
             os.execvpe(cmd[0], cmd, env)
         except FileNotFoundError as exc:
+            if flow_control_guard is not None:
+                flow_control_guard.terminate()
             raise SsmError("aws CLI not found on PATH.") from exc
         except OSError as exc:
+            if flow_control_guard is not None:
+                flow_control_guard.terminate()
             raise SsmError(f"Unable to start Session Manager session: {exc}") from exc
-    result = subprocess.run(cmd, env=env)
-    return int(result.returncode)
+    try:
+        result = subprocess.run(cmd, env=env)
+        return int(result.returncode)
+    finally:
+        if flow_control_guard is not None:
+            flow_control_guard.terminate()
+            try:
+                flow_control_guard.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                flow_control_guard.kill()

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -378,13 +378,17 @@ class TestStartSession:
 
     @patch("daylily_ec.aws.ssm.require_session_manager_plugin")
     @patch("daylily_ec.aws.ssm.os.isatty", return_value=True)
+    @patch("daylily_ec.aws.ssm.subprocess.Popen")
     @patch("daylily_ec.aws.ssm.subprocess.run")
     def test_disables_local_software_flow_control_before_session(
         self,
         mock_run,
+        mock_popen,
         _mock_isatty,
         _mock_require_plugin,
     ):
+        guard = MagicMock()
+        mock_popen.return_value = guard
         mock_run.side_effect = [
             subprocess.CompletedProcess(
                 args=[],
@@ -401,6 +405,12 @@ class TestStartSession:
         assert rc == 0
         assert mock_run.call_args_list[1].args[0] == ["stty", "-ixon", "-ixoff"]
         assert mock_run.call_args_list[2].args[0][:3] == ["aws", "ssm", "start-session"]
+        guard_cmd = mock_popen.call_args.args[0]
+        assert guard_cmd[1] == "-c"
+        assert "stty" in guard_cmd[2]
+        assert "-ixon" in guard_cmd[2]
+        guard.terminate.assert_called_once_with()
+        guard.wait.assert_called_once_with(timeout=2)
 
     @patch("daylily_ec.aws.ssm.require_session_manager_plugin")
     @patch("daylily_ec.aws.ssm.subprocess.run")


### PR DESCRIPTION
## Summary
- keeps a local flow-control guard running while Session Manager owns the terminal
- prevents the Session Manager/plugin path from re-enabling local XON/XOFF after connect starts
- preserves the existing remote ubuntu login-shell and SSM document validation behavior

## Validation
- pytest tests/test_ssm.py -q
- ruff check daylily_ec/aws/ssm.py tests/test_ssm.py
- ruff format --check daylily_ec/aws/ssm.py tests/test_ssm.py
- live at-sanity SSM test: cat -v receives bare Ctrl-S as ^S
- live at-sanity Emacs test: Ctrl-S enters I-search and Ctrl-X Ctrl-S writes the file
