### PR TITLE
Add headnode flow control guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@
 - Do not use `root` for headnode work. The `ubuntu` user is in sudoers; use targeted `sudo` from `ubuntu` only when escalation is required.
 - Interactive sessions must use `SSM-SessionManagerRunShell` configured with `runAsDefaultUser=ubuntu` and bash login-shell behavior.
 - Command payloads must go through the central `daylily_ec.aws.ssm.run_shell` and `daylily_ec.aws.ssm.write_remote_text` helpers rather than ad hoc `aws ssm send-command` calls.
+- `daylily-ec headnode connect` must preserve interactive TUI/editor key chords, especially Emacs `Ctrl-S` and `Ctrl-X Ctrl-S`. Keep both layers of XON/XOFF protection: the remote ubuntu login shell must disable flow control, and the local `daylily_ec.aws.ssm.start_session` path must keep a local `/dev/tty` flow-control guard running while Session Manager owns the terminal. A one-time local `stty -ixon -ixoff` is not sufficient because the AWS Session Manager/plugin startup path can leave the live local TTY with flow control enabled again.
+- Do not remove or bypass the `tests/test_ssm.py` guardrail coverage for the local flow-control guard. Regression evidence should include a real `daylily-ec headnode connect` session where `cat -v` receives bare `Ctrl-S` as `^S`; for editor validation, `emacs -Q` should enter `I-search` on `Ctrl-S` and write the file on `Ctrl-X Ctrl-S`.
 
 # Local Environment
 

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -22,6 +22,16 @@ from daylily_ec.aws.ssm import (
 )
 
 
+def _assert_flow_control_guard_command(mock_popen: MagicMock) -> None:
+    guard_cmd = mock_popen.call_args.args[0]
+    assert guard_cmd[1] == "-c"
+    assert "stty" in guard_cmd[2]
+    assert "-ixon" in guard_cmd[2]
+    assert "-ixoff" in guard_cmd[2]
+    assert "/dev/tty" in guard_cmd[2]
+    assert "time.sleep(0.1)" in guard_cmd[2]
+
+
 class TestRequireSessionManagerPlugin:
     @patch("daylily_ec.aws.ssm.shutil.which", return_value="/usr/local/bin/session-manager-plugin")
     def test_present(self, _mock_which):
@@ -405,12 +415,62 @@ class TestStartSession:
         assert rc == 0
         assert mock_run.call_args_list[1].args[0] == ["stty", "-ixon", "-ixoff"]
         assert mock_run.call_args_list[2].args[0][:3] == ["aws", "ssm", "start-session"]
-        guard_cmd = mock_popen.call_args.args[0]
-        assert guard_cmd[1] == "-c"
-        assert "stty" in guard_cmd[2]
-        assert "-ixon" in guard_cmd[2]
+        _assert_flow_control_guard_command(mock_popen)
         guard.terminate.assert_called_once_with()
         guard.wait.assert_called_once_with(timeout=2)
+
+    @patch("daylily_ec.aws.ssm.require_session_manager_plugin")
+    @patch("daylily_ec.aws.ssm.os.execvpe")
+    @patch("daylily_ec.aws.ssm.os.isatty", return_value=True)
+    @patch("daylily_ec.aws.ssm.subprocess.Popen")
+    @patch("daylily_ec.aws.ssm.subprocess.run")
+    def test_replace_process_keeps_flow_control_guard_running_through_exec(
+        self,
+        mock_run,
+        mock_popen,
+        _mock_isatty,
+        mock_execvpe,
+        _mock_require_plugin,
+    ):
+        class ExecCalled(Exception):
+            pass
+
+        order: list[str] = []
+        guard = MagicMock()
+
+        def start_guard(*args, **kwargs):
+            order.append("guard")
+            return guard
+
+        def exec_session(*args, **kwargs):
+            order.append("exec")
+            raise ExecCalled()
+
+        mock_popen.side_effect = start_guard
+        mock_execvpe.side_effect = exec_session
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout='{"inputs":{"runAsEnabled":true,"runAsDefaultUser":"ubuntu","shellProfile":{"linux":"cd /home/ubuntu && { stty -ixon -ixoff 2>/dev/null || true; exec bash -l; }"}}}',
+                stderr="",
+            ),
+            subprocess.CompletedProcess(args=["stty"], returncode=0, stdout="", stderr=""),
+        ]
+
+        with pytest.raises(ExecCalled):
+            start_session(
+                "i-abc123",
+                "us-west-2",
+                profile="dev",
+                replace_process=True,
+            )
+
+        assert order == ["guard", "exec"]
+        assert mock_run.call_args_list[1].args[0] == ["stty", "-ixon", "-ixoff"]
+        _assert_flow_control_guard_command(mock_popen)
+        guard.terminate.assert_not_called()
+        guard.wait.assert_not_called()
 
     @patch("daylily_ec.aws.ssm.require_session_manager_plugin")
     @patch("daylily_ec.aws.ssm.subprocess.run")


### PR DESCRIPTION
## Summary
- documents the headnode connect flow-control contract in AGENTS.md
- adds regression tests for the local /dev/tty flow-control guard
- verifies the guard starts before the replace-process exec path and remains alive through exec

## Validation
- pytest tests/test_ssm.py -q
- ruff check tests/test_ssm.py
- ruff format --check tests/test_ssm.py
- git diff --check
