### PR TITLE
[codex] Pin bootstrap release to 2.2.8

### DIFF
--- a/config/daylily_cli_global.yaml
+++ b/config/daylily_cli_global.yaml
@@ -1,7 +1,7 @@
 ---
 daylily:
-  git_ephemeral_cluster_repo_tag: 2.2.6
-  git_ephemeral_cluster_repo_release_tag: 2.2.6
+  git_ephemeral_cluster_repo_tag: 2.2.8
+  git_ephemeral_cluster_repo_release_tag: 2.2.8
   git_ephemeral_cluster_repo: https://github.com/Daylily-Informatics/daylily-ephemeral-cluster.git
   analysis_root: /fsx/analysis_results/
   sentieon_lic_path: /fsx/data/cached_envs/x.lic

--- a/daylily_ec/resources/payload/config/daylily_cli_global.yaml
+++ b/daylily_ec/resources/payload/config/daylily_cli_global.yaml
@@ -1,7 +1,7 @@
 ---
 daylily:
-  git_ephemeral_cluster_repo_tag: 2.2.6
-  git_ephemeral_cluster_repo_release_tag: 2.2.6
+  git_ephemeral_cluster_repo_tag: 2.2.8
+  git_ephemeral_cluster_repo_release_tag: 2.2.8
   git_ephemeral_cluster_repo: https://github.com/Daylily-Informatics/daylily-ephemeral-cluster.git
   analysis_root: /fsx/analysis_results/
   sentieon_lic_path: /fsx/data/cached_envs/x.lic


### PR DESCRIPTION
Updates source and packaged daylily_cli_global.yaml to pin daylily-ephemeral-cluster bootstrap/release config to tag 2.2.8. Validation: pytest tests/test_packaged_defaults.py -q; git diff --check.