### PR TITLE
Implement direct analysis DRA export

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest release](https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2FDaylily-Informatics%2Fdaylily-ephemeral-cluster%2Fmain%2Fconfig%2Fdaylily_cli_global.yaml&query=%24.daylily.git_ephemeral_cluster_repo_release_tag&label=latest%20release&cacheSeconds=300&color=teal)](https://github.com/Daylily-Informatics/daylily-ephemeral-cluster/releases) [![Latest tag](https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2FDaylily-Informatics%2Fdaylily-ephemeral-cluster%2Fmain%2Fconfig%2Fdaylily_cli_global.yaml&query=%24.daylily.git_ephemeral_cluster_repo_tag&label=latest%20tag&color=pink&cacheSeconds=300)](https://github.com/Daylily-Informatics/daylily-ephemeral-cluster/tags)
 
-DayEC is the operator control plane for short-lived AWS ParallelCluster environments that run Daylily analysis workloads on FSx for Lustre. The current data plane is DRA-first: the cluster starts with reference data mounted at `/fsx/data`, run folders are attached only when needed under `/fsx/run_dir_mounts/<mount_id>`, workflow outputs stay under `/fsx/analysis_results/...`, and selected results are exported through a temporary `/fsx/exports/<export_id>` DRA to a chosen S3 analysis bucket.
+DayEC is the operator control plane for short-lived AWS ParallelCluster environments that run Daylily analysis workloads on FSx for Lustre. The current data plane is DRA-first: the cluster starts with reference data mounted at `/fsx/data`, run folders are attached only when needed under `/fsx/run_dir_mounts/<mount_id>`, workflow outputs stay under `/fsx/analysis_results/ubuntu/<analysis_dir>`, and completed analysis directories are exported through a temporary direct DRA to a chosen S3 analysis bucket.
 
 The cluster is ephemeral. S3 buckets are durable. Verify the export receipt before deleting the cluster.
 
@@ -16,11 +16,10 @@ Use the checkout environment and the CLI, not historical helper-script paths:
 4. `dyec headnode connect`
 5. `dyec samples stage` for sample-manifest inputs, or `dyec mounts create` for run-folder inputs
 6. `dyec workflow launch`
-7. copy selected outputs into `/fsx/exports/<export_id>/...`
-8. `dyec export --export-id <id> --source-path /exports/<id>/... --destination-s3-uri s3://...`
-9. inspect `fsx_export.yaml`
-10. `dyec delete --dry-run`
-11. `dyec delete`
+7. `dyec export --source-path /fsx/analysis_results/ubuntu/<analysis_dir> --destination-s3-uri s3://bucket/analysis_results/ubuntu/<analysis_dir>/`
+8. inspect `fsx_export.yaml`
+9. `dyec delete --dry-run`
+10. `dyec delete`
 
 `daylily-ec` and `dyec` are the same entrypoint. The shorter `dyec` form is used in examples.
 
@@ -36,11 +35,11 @@ export CLUSTER_NAME=day-demo-$(date +%Y%m%d%H%M%S)
 export DAY_EX_CFG="$HOME/.config/daylily/daylily_ephemeral_cluster.yaml"
 export REF_BUCKET=s3://lsmc-dayoa-omics-analysis-us-west-2
 export ANALYSIS_BUCKET=s3://lsmc-dayoa-analysis-results-us-west-2
+export ANALYSIS_DIR=dayoa
 export ANALYSIS_SAMPLES=etc/analysis_samples_template.tsv
 export STAGE_CFG_DIR="$PWD/tmp-stage-config/$CLUSTER_NAME"
-export EXPORT_DIR="$PWD/tmp-export/$CLUSTER_NAME"
-export EXPORT_ID="${CLUSTER_NAME}-results"
-export EXPORT_S3_URI="$ANALYSIS_BUCKET/$EXPORT_ID/"
+export EXPORT_DIR="$PWD/tmp-export/$ANALYSIS_DIR"
+export EXPORT_S3_URI="$ANALYSIS_BUCKET/analysis_results/ubuntu/$ANALYSIS_DIR/"
 
 dyec preflight \
   --profile "$AWS_PROFILE" \
@@ -68,7 +67,7 @@ dyec workflow launch \
   --region "$REGION" \
   --cluster "$CLUSTER_NAME" \
   --stage-dir "/fsx/data/staged_sample_data/remote_stage_<timestamp>" \
-  --destination "<analysis-run-id>" \
+  --destination "$ANALYSIS_DIR" \
   --git-tag 1.0.7
 
 # For run-folder work, attach only the S3 prefix you need.
@@ -98,16 +97,11 @@ dyec workflow launch \
   --git-tag 1.0.7 \
   --dy-command "bin/day_run produce_illumina_run_qc --config run_context_file=config/runs.tsv -p -j 5 -k"
 
-# On the headnode, copy only the outputs you want to export:
-#   mkdir -p /fsx/exports/$EXPORT_ID/analysis_results/ubuntu/
-#   cp -a /fsx/analysis_results/ubuntu/<analysis-run-id>/ /fsx/exports/$EXPORT_ID/analysis_results/ubuntu/
-
 dyec export \
   --profile "$AWS_PROFILE" \
   --region "$REGION" \
   --cluster "$CLUSTER_NAME" \
-  --export-id "$EXPORT_ID" \
-  --source-path "/exports/$EXPORT_ID/analysis_results/ubuntu/" \
+  --source-path "/fsx/analysis_results/ubuntu/$ANALYSIS_DIR" \
   --destination-s3-uri "$EXPORT_S3_URI" \
   --output-dir "$EXPORT_DIR"
 
@@ -133,9 +127,8 @@ flowchart LR
   Data --> Workflow["DayOA workflow"]
   Mount --> Workflow
   Workflow --> Results["/fsx/analysis_results/..."]
-  Results --> Copy["copy selected outputs"]
-  Copy --> Export["/fsx/exports/<export_id>"]
-  Export -->|EXPORT_TO_REPOSITORY| Analysis["S3 analysis bucket/prefix"]
+  Results --> Export["temporary direct export DRA on /analysis_results/ubuntu/<analysis_dir>/"]
+  Export -->|EXPORT_TO_REPOSITORY| Analysis["S3 analysis bucket /analysis_results/ubuntu/<analysis_dir>/"]
 ```
 
 Key rules:
@@ -143,8 +136,8 @@ Key rules:
 - `/fsx/data` is the reference-data DRA created with the cluster.
 - `/fsx/run_dir_mounts/<mount_id>` is for read-oriented run inputs and is not an export source.
 - `/fsx/analysis_results/...` is where workflow checkouts and outputs live.
-- `/fsx/exports/<export_id>` is the temporary export namespace for selected outputs.
-- `fsx_export.yaml` is the export receipt to keep before teardown.
+- `dyec export` creates a temporary DRA on the exact completed analysis directory, runs `EXPORT_TO_REPOSITORY`, and detaches it with `DeleteDataInFileSystem=false`.
+- `fsx_export.yaml` is the v3 export receipt to keep before teardown.
 
 ## Pipeline Catalog
 

--- a/README.md.bland
+++ b/README.md.bland
@@ -5,7 +5,7 @@ DayEC creates short-lived AWS ParallelCluster environments for Daylily analysis 
 - references: `/fsx/data`
 - run folders: `/fsx/run_dir_mounts/<mount_id>`
 - workflow outputs: `/fsx/analysis_results/...`
-- selected export payloads: `/fsx/exports/<export_id>`
+- direct export source: `/fsx/analysis_results/ubuntu/<analysis_dir>`
 
 The cluster is disposable. S3 is durable. Export and verify `fsx_export.yaml` before delete.
 
@@ -21,11 +21,11 @@ export CLUSTER_NAME=day-demo-$(date +%Y%m%d%H%M%S)
 export DAY_EX_CFG="$HOME/.config/daylily/daylily_ephemeral_cluster.yaml"
 export REF_BUCKET=s3://lsmc-dayoa-omics-analysis-us-west-2
 export ANALYSIS_BUCKET=s3://lsmc-dayoa-analysis-results-us-west-2
+export ANALYSIS_DIR=dayoa
 export ANALYSIS_SAMPLES=etc/analysis_samples_template.tsv
 export STAGE_CFG_DIR="$PWD/tmp-stage-config/$CLUSTER_NAME"
-export EXPORT_DIR="$PWD/tmp-export/$CLUSTER_NAME"
-export EXPORT_ID="${CLUSTER_NAME}-results"
-export EXPORT_S3_URI="$ANALYSIS_BUCKET/$EXPORT_ID/"
+export EXPORT_DIR="$PWD/tmp-export/$ANALYSIS_DIR"
+export EXPORT_S3_URI="$ANALYSIS_BUCKET/analysis_results/ubuntu/$ANALYSIS_DIR/"
 
 dyec preflight --profile "$AWS_PROFILE" --region-az "$REGION_AZ" --config "$DAY_EX_CFG"
 dyec create --profile "$AWS_PROFILE" --region-az "$REGION_AZ" --config "$DAY_EX_CFG"
@@ -42,15 +42,14 @@ dyec workflow launch \
   --region "$REGION" \
   --cluster "$CLUSTER_NAME" \
   --stage-dir "/fsx/data/staged_sample_data/remote_stage_<timestamp>" \
-  --destination dayoa \
+  --destination "$ANALYSIS_DIR" \
   --git-tag 1.0.7
 
 dyec export \
   --profile "$AWS_PROFILE" \
   --region "$REGION" \
   --cluster "$CLUSTER_NAME" \
-  --export-id "$EXPORT_ID" \
-  --source-path "/exports/$EXPORT_ID/analysis_results/ubuntu/" \
+  --source-path "/fsx/analysis_results/ubuntu/$ANALYSIS_DIR" \
   --destination-s3-uri "$EXPORT_S3_URI" \
   --output-dir "$EXPORT_DIR"
 
@@ -83,7 +82,7 @@ dyec --json mounts verify \
   --mount-id RUN123
 ```
 
-Run mounts are input-oriented. Do not write outputs into `/fsx/run_dir_mounts`. Export selected results from `/fsx/exports/<export_id>` instead.
+Run mounts are input-oriented. Do not write outputs into `/fsx/run_dir_mounts`. Export completed analysis directories from `/fsx/analysis_results/ubuntu/<analysis_dir>` instead.
 
 ## Read More
 

--- a/bin/daylily-export-fsx-to-s3
+++ b/bin/daylily-export-fsx-to-s3
@@ -9,9 +9,9 @@ import sys
 def main() -> int:
     sys.stderr.write(
         "Legacy positional FSx export is removed. Use `daylily-ec export "
-        "--export-id ID --source-path /exports/ID/... "
-        "--destination-s3-uri s3://bucket/prefix/ --cluster-name CLUSTER "
-        "--region REGION --output-dir DIR`.\n"
+        "--source-path /fsx/analysis_results/ubuntu/ANALYSIS_DIR "
+        "--destination-s3-uri s3://bucket/analysis_results/ubuntu/ANALYSIS_DIR/ "
+        "--cluster-name CLUSTER --region REGION --output-dir DIR`.\n"
     )
     return 2
 

--- a/bin/daylily-export-fsx-to-s3-from-local
+++ b/bin/daylily-export-fsx-to-s3-from-local
@@ -14,7 +14,6 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--cluster", "--cluster-name", dest="cluster_name")
     parser.add_argument("--fsx-file-system-id")
-    parser.add_argument("--export-id", required=True)
     parser.add_argument("--source-path", required=True)
     parser.add_argument("--destination-s3-uri", required=True)
     parser.add_argument("--region", required=True)
@@ -42,8 +41,6 @@ def main(argv: list[str] | None = None) -> int:
     cmd = [
         *_resolve_entrypoint(),
         "export",
-        "--export-id",
-        args.export_id,
         "--source-path",
         args.source_path,
         "--destination-s3-uri",

--- a/daylily_ec/cli.py
+++ b/daylily_ec/cli.py
@@ -955,15 +955,10 @@ def export(
         "--fsx-file-system-id",
         help="Explicit FSx file system id. Required when --cluster is omitted.",
     ),
-    export_id: str = typer.Option(
-        ...,
-        "--export-id",
-        help="Safe export id mounted under /fsx/exports/<export-id>/.",
-    ),
     source_path: str = typer.Option(
         ...,
         "--source-path",
-        help="Explicit FSx API path to export, under /exports/<export-id>/.",
+        help="Completed analysis directory under /fsx/analysis_results/ubuntu/<analysis-dir>/.",
     ),
     destination_s3_uri: str = typer.Option(
         ...,
@@ -1007,7 +1002,6 @@ def export(
         ExportOptions(
             cluster_name=cluster_name,
             fsx_file_system_id=fsx_file_system_id,
-            export_id=export_id,
             source_path=source_path,
             destination_s3_uri=destination_s3_uri,
             region=region,
@@ -1030,14 +1024,14 @@ def _emit_export_payload(payload: Any, *, text: str) -> None:
 def exports_attach(
     cluster_name: Optional[str] = typer.Option(None, "--cluster-name", "--cluster"),
     fsx_file_system_id: Optional[str] = typer.Option(None, "--fsx-file-system-id"),
-    export_id: str = typer.Option(..., "--export-id"),
+    source_path: str = typer.Option(..., "--source-path"),
     destination_s3_uri: str = typer.Option(..., "--destination-s3-uri"),
     region: str = typer.Option(..., "--region"),
     profile: Optional[str] = typer.Option(None, "--profile"),
     wait: bool = typer.Option(True, "--wait/--no-wait"),
     timeout_seconds: int = typer.Option(900, "--timeout-seconds"),
 ) -> None:
-    """Attach a temporary output DRA under /fsx/exports/<export-id>/."""
+    """Attach a temporary output DRA to a completed analysis directory."""
 
     from daylily_ec.workflow.export_data import attach_export_dra
 
@@ -1045,7 +1039,7 @@ def exports_attach(
         record = attach_export_dra(
             cluster_name=cluster_name,
             fsx_file_system_id=fsx_file_system_id,
-            export_id=export_id,
+            source_path=source_path,
             destination_s3_uri=destination_s3_uri,
             region=region,
             profile=profile,
@@ -1067,7 +1061,6 @@ def exports_attach(
 def exports_run(
     cluster_name: Optional[str] = typer.Option(None, "--cluster-name", "--cluster"),
     fsx_file_system_id: Optional[str] = typer.Option(None, "--fsx-file-system-id"),
-    export_id: str = typer.Option(..., "--export-id"),
     source_path: str = typer.Option(..., "--source-path"),
     destination_s3_uri: str = typer.Option(..., "--destination-s3-uri"),
     region: str = typer.Option(..., "--region"),
@@ -1075,7 +1068,7 @@ def exports_run(
     wait: bool = typer.Option(True, "--wait/--no-wait"),
     timeout_seconds: int = typer.Option(3600, "--timeout-seconds"),
 ) -> None:
-    """Run an explicit FSx export task for /exports/<export-id>/ paths."""
+    """Run an explicit FSx export task for an analysis directory."""
 
     from daylily_ec.workflow.export_data import (
         _create_session,
@@ -1092,7 +1085,6 @@ def exports_run(
         )
         payload = run_export_task(
             fsx_file_system_id=resolved_fsx_id,
-            export_id=export_id,
             source_path=source_path,
             destination_s3_uri=destination_s3_uri,
             wait=wait,

--- a/daylily_ec/resources/payload/bin/daylily-export-fsx-to-s3
+++ b/daylily_ec/resources/payload/bin/daylily-export-fsx-to-s3
@@ -9,9 +9,9 @@ import sys
 def main() -> int:
     sys.stderr.write(
         "Legacy positional FSx export is removed. Use `daylily-ec export "
-        "--export-id ID --source-path /exports/ID/... "
-        "--destination-s3-uri s3://bucket/prefix/ --cluster-name CLUSTER "
-        "--region REGION --output-dir DIR`.\n"
+        "--source-path /fsx/analysis_results/ubuntu/ANALYSIS_DIR "
+        "--destination-s3-uri s3://bucket/analysis_results/ubuntu/ANALYSIS_DIR/ "
+        "--cluster-name CLUSTER --region REGION --output-dir DIR`.\n"
     )
     return 2
 

--- a/daylily_ec/resources/payload/bin/daylily-export-fsx-to-s3-from-local
+++ b/daylily_ec/resources/payload/bin/daylily-export-fsx-to-s3-from-local
@@ -14,7 +14,6 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--cluster", "--cluster-name", dest="cluster_name")
     parser.add_argument("--fsx-file-system-id")
-    parser.add_argument("--export-id", required=True)
     parser.add_argument("--source-path", required=True)
     parser.add_argument("--destination-s3-uri", required=True)
     parser.add_argument("--region", required=True)
@@ -29,7 +28,7 @@ def _resolve_entrypoint() -> list[str]:
     if cli:
         return [cli]
 
-    repo_root = Path(__file__).resolve().parents[4]
+    repo_root = Path(__file__).resolve().parents[1]
     if (repo_root / "daylily_ec" / "__main__.py").is_file():
         os.chdir(repo_root)
         return [sys.executable, "-m", "daylily_ec"]
@@ -42,8 +41,6 @@ def main(argv: list[str] | None = None) -> int:
     cmd = [
         *_resolve_entrypoint(),
         "export",
-        "--export-id",
-        args.export_id,
         "--source-path",
         args.source_path,
         "--destination-s3-uri",

--- a/daylily_ec/resources/payload/etc/fsx_export.yaml
+++ b/daylily_ec/resources/payload/etc/fsx_export.yaml
@@ -1,3 +1,18 @@
 fsx_export:
+  schema_version: 3
   status: success
-  s3_uri: s3://lsmc-dayoa-omics-analysis-us-west-2/FSxLustre20251015T090232Z/analysis_results/ubuntu/test_help
+  phase: complete
+  cluster_name: dra-test4
+  region: us-west-2
+  analysis_dir: illumina_run_qc
+  source_path: /analysis_results/ubuntu/illumina_run_qc/
+  headnode_path: /fsx/analysis_results/ubuntu/illumina_run_qc/
+  destination_s3_uri: s3://lsmc-dayoa-omics-analysis-us-west-2/analysis_results/ubuntu/illumina_run_qc/
+  fsx_file_system_id: fs-1234567890abcdef0
+  association_id: dra-1234567890abcdef0
+  task_id: task-1234567890abcdef0
+  task_lifecycle: SUCCEEDED
+  report_path: s3://lsmc-dayoa-omics-analysis-us-west-2/daylily-monitor/fsx-export/illumina_run_qc/20260518T000000Z/export-report/
+  detached: true
+  delete_data_in_file_system: false
+  failure_details: {}

--- a/daylily_ec/ssh_to_ssm_e2e_runner.py
+++ b/daylily_ec/ssh_to_ssm_e2e_runner.py
@@ -131,14 +131,9 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         help="Directory for export artifacts (default: tmp-e2e-export/<cluster>)",
     )
     parser.add_argument(
-        "--export-id",
-        default=None,
-        help="Explicit export DRA id mounted under /fsx/exports/<id>/.",
-    )
-    parser.add_argument(
         "--export-source-path",
         default=None,
-        help="Explicit FSx API path under /exports/<export-id>/ to export.",
+        help="Completed analysis directory under /fsx/analysis_results/ubuntu/<analysis-dir>/.",
     )
     parser.add_argument(
         "--export-destination-s3-uri",
@@ -660,6 +655,11 @@ def _validate_export_artifact(
     expected_source_path: str,
     expected_destination_s3_uri: str,
 ) -> dict[str, object]:
+    from daylily_ec.workflow.export_data import (
+        normalize_export_source_path,
+        validate_export_destination_s3_uri,
+    )
+
     if not export_yaml.is_file():
         raise CommandError(f"Export did not write expected artifact: {export_yaml}")
     payload = yaml.safe_load(export_yaml.read_text(encoding="utf-8")) or {}
@@ -667,16 +667,21 @@ def _validate_export_artifact(
     status = str(export_payload.get("status") or "")
     if status != "success":
         raise CommandError(f"Export status is not success in {export_yaml}: {status or 'missing'}")
+    normalized_expected_source = normalize_export_source_path(expected_source_path)
+    normalized_expected_destination = validate_export_destination_s3_uri(
+        expected_destination_s3_uri,
+        source_path=normalized_expected_source,
+    )
     destination = str(export_payload.get("destination_s3_uri") or "")
-    if destination.rstrip("/") != expected_destination_s3_uri.rstrip("/"):
+    if destination != normalized_expected_destination:
         raise CommandError(
             f"Export destination {destination!r} does not match "
-            f"{expected_destination_s3_uri!r}."
+            f"{normalized_expected_destination!r}."
         )
     source = str(export_payload.get("source_path") or "")
-    if source.rstrip("/") != expected_source_path.rstrip("/"):
+    if source != normalized_expected_source:
         raise CommandError(
-            f"Export source {source!r} does not match {expected_source_path!r}."
+            f"Export source {source!r} does not match {normalized_expected_source!r}."
         )
     if not export_payload.get("association_id") or not export_payload.get("task_id"):
         raise CommandError(
@@ -947,9 +952,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if args.skip_export:
         _record_step(summary, output_json, "export-results", "skipped", reason="--skip-export")
     else:
-        if not args.export_id or not args.export_source_path or not args.export_destination_s3_uri:
+        if not args.export_source_path or not args.export_destination_s3_uri:
             raise CommandError(
-                "--export-id, --export-source-path, and --export-destination-s3-uri "
+                "--export-source-path and --export-destination-s3-uri "
                 "are required unless --skip-export is set."
             )
         export_output_dir.mkdir(parents=True, exist_ok=True)
@@ -960,8 +965,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             args.cluster_name,
             "--region",
             args.region,
-            "--export-id",
-            args.export_id,
             "--source-path",
             args.export_source_path,
             "--destination-s3-uri",

--- a/daylily_ec/workflow/export_data.py
+++ b/daylily_ec/workflow/export_data.py
@@ -1,13 +1,14 @@
-"""Explicit FSx DRA export workflow for the ``daylily-ec export`` command."""
+"""Direct analysis-directory FSx DRA export workflow."""
 
 from __future__ import annotations
 
 import dataclasses
 import logging
-import shlex
 import time
+from datetime import datetime, timezone
 from pathlib import PurePosixPath, Path
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
+from urllib.parse import urlparse
 
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
@@ -16,8 +17,11 @@ import yaml
 from daylily_ec import ui
 from daylily_ec.run_mounts import (
     RunMountError,
+    association_is_active,
     describe_fsx_file_system,
+    describe_data_repository_associations,
     normalize_s3_uri,
+    paths_overlap,
     resolve_fsx_file_system_id,
     validate_dra_compatible_file_system,
     wait_for_association,
@@ -26,10 +30,10 @@ from daylily_ec.run_mounts import (
 
 LOGGER = logging.getLogger("daylily.export_fsx")
 
-EXPORT_ROOT = "/exports/"
-HEADNODE_EXPORT_ROOT = "/fsx/exports/"
+ANALYSIS_EXPORT_ROOT = "/analysis_results/ubuntu/"
+HEADNODE_ANALYSIS_EXPORT_ROOT = "/fsx/analysis_results/ubuntu/"
 STATUS_FILENAME = "fsx_export.yaml"
-EXPORT_SCHEMA_VERSION = 2
+EXPORT_SCHEMA_VERSION = 3
 EXPORT_PURPOSE_TAG = "output-export"
 POLL_INTERVAL_SECONDS = 30
 
@@ -42,7 +46,6 @@ class ExportError(RuntimeError):
 class ExportOptions:
     cluster_name: Optional[str]
     fsx_file_system_id: Optional[str]
-    export_id: str
     source_path: str
     destination_s3_uri: str
     region: str
@@ -54,7 +57,7 @@ class ExportOptions:
 
 @dataclasses.dataclass(frozen=True)
 class ExportDraRecord:
-    export_id: str
+    analysis_dir: str
     cluster_name: Optional[str]
     region: str
     fsx_file_system_id: str
@@ -81,31 +84,45 @@ def _create_session(region: str, profile: Optional[str]):
     return boto3.Session(**session_kwargs)
 
 
-def normalize_export_id(export_id: str) -> str:
-    candidate = str(export_id or "").strip()
+def _safe_analysis_dir(candidate: str) -> str:
     if not candidate:
-        raise ExportError("export_id is required.")
+        raise ExportError("source_path must include one analysis directory.")
     if candidate in {".", ".."} or ".." in candidate or "/" in candidate or "%" in candidate:
-        raise ExportError("export_id must be a single safe path component.")
+        raise ExportError("analysis_dir must be a single safe path component.")
     return candidate
 
 
-def export_file_system_path(export_id: str) -> str:
-    return f"{EXPORT_ROOT}{normalize_export_id(export_id)}/"
+def analysis_headnode_path(source_path: str) -> str:
+    normalized = normalize_export_source_path(source_path)
+    return f"{HEADNODE_ANALYSIS_EXPORT_ROOT}{analysis_dir_from_source_path(normalized)}/"
 
 
-def export_headnode_path(export_id: str) -> str:
-    return f"{HEADNODE_EXPORT_ROOT}{normalize_export_id(export_id)}/"
+def analysis_dir_from_source_path(source_path: str) -> str:
+    normalized = normalize_export_source_path(source_path)
+    suffix = normalized[len(ANALYSIS_EXPORT_ROOT) :].strip("/")
+    return _safe_analysis_dir(suffix)
 
 
-def normalize_export_source_path(source_path: str, *, export_id: str) -> str:
+def normalize_export_source_path(source_path: str) -> str:
     raw = str(source_path or "").strip()
     if not raw:
         raise ExportError("source_path is required.")
-    if raw.startswith(HEADNODE_EXPORT_ROOT):
-        raw = EXPORT_ROOT + raw[len(HEADNODE_EXPORT_ROOT) :]
-    if raw.startswith("/fsx/run_dir_mounts/") or raw.startswith("/run_dir_mounts/"):
+    if raw.startswith("/fsx/run_dir_mounts/") or raw == "/fsx/run_dir_mounts":
         raise ExportError("Run-directory mounts are read-oriented inputs, not export sources.")
+    if raw.startswith("/fsx/data/") or raw == "/fsx/data":
+        raise ExportError("Reference data under /fsx/data is not an export source.")
+    if raw.startswith("/fsx/exports/") or raw == "/fsx/exports":
+        raise ExportError("The /fsx/exports staging namespace is not supported.")
+    if raw.startswith(HEADNODE_ANALYSIS_EXPORT_ROOT):
+        raw = ANALYSIS_EXPORT_ROOT + raw[len(HEADNODE_ANALYSIS_EXPORT_ROOT) :]
+    elif raw.startswith("/fsx/"):
+        raise ExportError("source_path must be under /fsx/analysis_results/ubuntu/<analysis_dir>.")
+    if raw.startswith("/run_dir_mounts/"):
+        raise ExportError("Run-directory mounts are read-oriented inputs, not export sources.")
+    if raw.startswith("/data/") or raw == "/data":
+        raise ExportError("Reference data under /fsx/data is not an export source.")
+    if raw.startswith("/exports/") or raw == "/exports":
+        raise ExportError("The /fsx/exports staging namespace is not supported.")
     if not raw.startswith("/"):
         raise ExportError("source_path must be an absolute FSx path.")
     if "//" in raw:
@@ -114,10 +131,25 @@ def normalize_export_source_path(source_path: str, *, export_id: str) -> str:
     if ".." in parts:
         raise ExportError("source_path must not contain '..'.")
     normalized = "/" + "/".join(part for part in parts if part != "/")
-    required_root = export_file_system_path(export_id)
-    if not normalized.rstrip("/").startswith(required_root.rstrip("/")):
-        raise ExportError(f"source_path must be under {required_root}.")
+    if not normalized.startswith(ANALYSIS_EXPORT_ROOT):
+        raise ExportError("source_path must be under /analysis_results/ubuntu/<analysis_dir>.")
+    suffix = normalized[len(ANALYSIS_EXPORT_ROOT) :].strip("/")
+    _safe_analysis_dir(suffix)
     return normalized.rstrip("/") + "/"
+
+
+def validate_export_destination_s3_uri(destination_s3_uri: str, *, source_path: str) -> str:
+    destination = normalize_s3_uri(destination_s3_uri)
+    parsed = urlparse(destination)
+    key = parsed.path.lstrip("/")
+    analysis_dir = analysis_dir_from_source_path(source_path)
+    expected_key = f"analysis_results/ubuntu/{analysis_dir}/"
+    if key != expected_key:
+        raise ExportError(
+            "destination_s3_uri must end with "
+            f"{expected_key!r}; got s3://{parsed.netloc}/{key}"
+        )
+    return destination
 
 
 def resolve_export_fsx_id(
@@ -133,19 +165,46 @@ def resolve_export_fsx_id(
     return resolve_fsx_file_system_id(client, cluster_name)
 
 
+def validate_no_overlapping_export_dra(
+    client: Any,
+    *,
+    fsx_file_system_id: str,
+    source_path: str,
+) -> None:
+    try:
+        associations = describe_data_repository_associations(
+            client,
+            filters=[{"Name": "file-system-id", "Values": [fsx_file_system_id]}],
+        )
+    except (BotoCoreError, ClientError, RunMountError) as exc:
+        raise ExportError(f"Unable to inspect existing FSx data repository associations: {exc}") from exc
+    normalized_source = normalize_export_source_path(source_path)
+    for association in associations:
+        if not association_is_active(association):
+            continue
+        existing_path = str(association.get("FileSystemPath") or "")
+        if existing_path and paths_overlap(existing_path, normalized_source):
+            association_id = str(association.get("AssociationId") or "unknown")
+            raise ExportError(
+                "source_path overlaps existing FSx data repository association "
+                f"{association_id} at {existing_path}."
+            )
+
+
 def attach_export_dra(
     *,
     cluster_name: Optional[str],
     fsx_file_system_id: Optional[str],
-    export_id: str,
+    source_path: str,
     destination_s3_uri: str,
     region: str,
     profile: Optional[str],
     wait: bool,
     timeout_seconds: int,
     fsx_client: Optional[Any] = None,
+    on_created: Optional[Callable[[ExportDraRecord], None]] = None,
 ) -> ExportDraRecord:
-    """Create an output DRA under /exports/<export_id>/ without AutoExport."""
+    """Create an output DRA directly on an analysis directory without AutoExport."""
     session = None if fsx_client is not None else _create_session(region, profile)
     client = fsx_client or session.client("fsx")
     resolved_fsx_id = resolve_export_fsx_id(
@@ -154,8 +213,16 @@ def attach_export_dra(
         fsx_file_system_id=fsx_file_system_id,
     )
     validate_dra_compatible_file_system(describe_fsx_file_system(client, resolved_fsx_id))
-    file_system_path = export_file_system_path(export_id)
-    destination = normalize_s3_uri(destination_s3_uri)
+    file_system_path = normalize_export_source_path(source_path)
+    destination = validate_export_destination_s3_uri(
+        destination_s3_uri,
+        source_path=file_system_path,
+    )
+    validate_no_overlapping_export_dra(
+        client,
+        fsx_file_system_id=resolved_fsx_id,
+        source_path=file_system_path,
+    )
     try:
         response = client.create_data_repository_association(
             FileSystemId=resolved_fsx_id,
@@ -164,7 +231,7 @@ def attach_export_dra(
             BatchImportMetaDataOnCreate=False,
             Tags=[
                 {"Key": "lsmc:purpose", "Value": EXPORT_PURPOSE_TAG},
-                {"Key": "Name", "Value": normalize_export_id(export_id)},
+                {"Key": "Name", "Value": analysis_dir_from_source_path(file_system_path)},
             ],
         )
     except (BotoCoreError, ClientError) as exc:
@@ -173,6 +240,19 @@ def attach_export_dra(
     association_id = str(association.get("AssociationId") or "")
     if not association_id:
         raise ExportError("FSx did not return an export data repository association id.")
+    created_record = ExportDraRecord(
+        analysis_dir=analysis_dir_from_source_path(file_system_path),
+        cluster_name=cluster_name,
+        region=region,
+        fsx_file_system_id=resolved_fsx_id,
+        file_system_path=str(association.get("FileSystemPath") or file_system_path),
+        headnode_path=analysis_headnode_path(file_system_path),
+        destination_s3_uri=destination,
+        association_id=association_id,
+        lifecycle=str(association.get("Lifecycle") or "UNKNOWN"),
+    )
+    if on_created is not None:
+        on_created(created_record)
     if wait:
         association = wait_for_association(
             client,
@@ -181,12 +261,12 @@ def attach_export_dra(
             timeout_seconds=timeout_seconds,
         )
     return ExportDraRecord(
-        export_id=normalize_export_id(export_id),
+        analysis_dir=analysis_dir_from_source_path(file_system_path),
         cluster_name=cluster_name,
         region=region,
         fsx_file_system_id=resolved_fsx_id,
         file_system_path=str(association.get("FileSystemPath") or file_system_path),
-        headnode_path=export_headnode_path(export_id),
+        headnode_path=analysis_headnode_path(file_system_path),
         destination_s3_uri=destination,
         association_id=association_id,
         lifecycle=str(association.get("Lifecycle") or "UNKNOWN"),
@@ -196,17 +276,23 @@ def attach_export_dra(
 def run_export_task(
     *,
     fsx_file_system_id: str,
-    export_id: str,
     source_path: str,
     destination_s3_uri: str,
     wait: bool,
     timeout_seconds: int,
     fsx_client: Any,
 ) -> Dict[str, Any]:
-    normalized_source = normalize_export_source_path(source_path, export_id=export_id)
+    normalized_source = normalize_export_source_path(source_path)
+    destination = validate_export_destination_s3_uri(
+        destination_s3_uri,
+        source_path=normalized_source,
+    )
+    destination_parts = urlparse(destination)
+    analysis_dir = analysis_dir_from_source_path(normalized_source)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     report_path = (
-        normalize_s3_uri(destination_s3_uri).rstrip("/")
-        + f"/daylily-monitor/{int(time.time())}/export-report"
+        f"s3://{destination_parts.netloc}/daylily-monitor/fsx-export/"
+        f"{analysis_dir}/{timestamp}/export-report/"
     )
     try:
         response = fsx_client.create_data_repository_task(
@@ -309,6 +395,7 @@ def _write_status(options: ExportOptions, payload: Dict[str, Any]) -> None:
 
 
 def _base_receipt(options: ExportOptions) -> Dict[str, Any]:
+    normalized_source = normalize_export_source_path(options.source_path)
     return {
         "fsx_export": {
             "schema_version": EXPORT_SCHEMA_VERSION,
@@ -316,13 +403,15 @@ def _base_receipt(options: ExportOptions) -> Dict[str, Any]:
             "phase": "attach",
             "cluster_name": options.cluster_name,
             "region": options.region,
-            "export_id": normalize_export_id(options.export_id),
-            "source_path": normalize_export_source_path(
-                options.source_path,
-                export_id=options.export_id,
+            "analysis_dir": analysis_dir_from_source_path(normalized_source),
+            "source_path": normalized_source,
+            "headnode_path": analysis_headnode_path(normalized_source),
+            "destination_s3_uri": validate_export_destination_s3_uri(
+                options.destination_s3_uri,
+                source_path=normalized_source,
             ),
-            "destination_s3_uri": normalize_s3_uri(options.destination_s3_uri),
             "detached": False,
+            "delete_data_in_file_system": False,
             "failure_details": {},
         }
     }
@@ -331,7 +420,7 @@ def _base_receipt(options: ExportOptions) -> Dict[str, Any]:
 def run_export_workflow(options: ExportOptions) -> int:
     """Attach an output DRA, run an explicit FSx export task, detach the DRA."""
     ui.phase("EXPORT")
-    ui.step(f"Preparing explicit FSx export for '{options.export_id}'")
+    ui.step("Preparing direct FSx export DRA")
 
     try:
         receipt = _base_receipt(options)
@@ -343,8 +432,10 @@ def run_export_workflow(options: ExportOptions) -> int:
                 "phase": "validate",
                 "cluster_name": options.cluster_name,
                 "region": options.region,
-                "export_id": options.export_id,
+                "source_path": options.source_path,
+                "destination_s3_uri": options.destination_s3_uri,
                 "detached": False,
+                "delete_data_in_file_system": False,
                 "failure_details": {"message": str(exc)},
             }
         }
@@ -360,16 +451,22 @@ def run_export_workflow(options: ExportOptions) -> int:
     message = ""
 
     try:
+        def _capture_created_dra(created_record: ExportDraRecord) -> None:
+            nonlocal record
+            record = created_record
+            receipt["fsx_export"].update(created_record.to_payload())
+
         record = attach_export_dra(
             cluster_name=options.cluster_name,
             fsx_file_system_id=options.fsx_file_system_id,
-            export_id=options.export_id,
+            source_path=options.source_path,
             destination_s3_uri=options.destination_s3_uri,
             region=options.region,
             profile=options.profile,
             wait=options.wait,
             timeout_seconds=options.timeout_seconds,
             fsx_client=client,
+            on_created=_capture_created_dra,
         )
         receipt["fsx_export"].update(record.to_payload())
         receipt["fsx_export"]["phase"] = "run"
@@ -377,8 +474,7 @@ def run_export_workflow(options: ExportOptions) -> int:
 
         task_payload = run_export_task(
             fsx_file_system_id=record.fsx_file_system_id,
-            export_id=record.export_id,
-            source_path=options.source_path,
+            source_path=record.file_system_path,
             destination_s3_uri=record.destination_s3_uri,
             wait=options.wait,
             timeout_seconds=options.timeout_seconds,
@@ -395,7 +491,10 @@ def run_export_workflow(options: ExportOptions) -> int:
     except (ClientError, BotoCoreError, RuntimeError, RunMountError, ExportError) as exc:
         message = str(exc)
         receipt["fsx_export"]["status"] = "error"
-        receipt["fsx_export"]["failure_details"] = {"message": message}
+        failure_details = {"message": message}
+        if task_payload.get("failure_details"):
+            failure_details["task_failure_details"] = task_payload["failure_details"]
+        receipt["fsx_export"]["failure_details"] = failure_details
         LOGGER.error("FSx export failed: %s", exc)
     finally:
         if record is not None:
@@ -438,5 +537,5 @@ def run_export_workflow(options: ExportOptions) -> int:
 
 
 def shell_copy_hint(record: ExportDraRecord) -> str:
-    """Return a copy command hint for operators who need the export path."""
-    return f"cp -a {shlex.quote('<outputs>')} {shlex.quote(record.headnode_path)}"
+    """Return the analysis directory path exported by *record*."""
+    return record.headnode_path

--- a/docs/aws_setup.md
+++ b/docs/aws_setup.md
@@ -77,7 +77,7 @@ Current FSx DRA strategy:
 
 - reference data DRA: `<reference-bucket>/data/` to `/fsx/data`
 - run input DRA: selected S3 run prefix to `/fsx/run_dir_mounts/<mount_id>`
-- export DRA: `/fsx/exports/<export_id>` to the requested S3 analysis destination
+- export DRA: one completed `/fsx/analysis_results/ubuntu/<analysis_dir>` to the requested S3 analysis destination
 
 The reference bucket is not automatically the export bucket. `dyec export` takes an explicit `--destination-s3-uri`.
 

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -221,15 +221,14 @@ Command classes:
 
 ## Export
 
-Root export runs the complete explicit output-DRA workflow:
+Root export runs the complete explicit output-DRA workflow on one completed analysis directory:
 
 ```bash
 dyec export \
   --profile "$AWS_PROFILE" \
   --region "$REGION" \
   --cluster "$CLUSTER_NAME" \
-  --export-id "$EXPORT_ID" \
-  --source-path "/exports/$EXPORT_ID/analysis_results/ubuntu/" \
+  --source-path "/fsx/analysis_results/ubuntu/$ANALYSIS_DIR" \
   --destination-s3-uri "$EXPORT_S3_URI" \
   --output-dir "$EXPORT_DIR"
 ```
@@ -237,19 +236,18 @@ dyec export \
 Required:
 
 - `--cluster` or `--fsx-file-system-id`
-- `--export-id`
 - `--source-path`
 - `--destination-s3-uri`
 - `--region`
 - `--output-dir`
 
-The source path must be under `/exports/<export_id>/`. Run mounts under `/run_dir_mounts/` are input paths and are rejected as export sources.
+The source path must be `/fsx/analysis_results/ubuntu/<analysis_dir>` or `/analysis_results/ubuntu/<analysis_dir>`. The destination must be an explicit S3 URI ending in `analysis_results/ubuntu/<analysis_dir>/`. Run mounts, reference data, nested paths, and old export staging paths are rejected as export sources.
 
 Lower-level helpers:
 
 ```bash
-dyec --json exports attach --profile "$AWS_PROFILE" --region "$REGION" --cluster "$CLUSTER_NAME" --export-id "$EXPORT_ID" --destination-s3-uri "$EXPORT_S3_URI"
-dyec --json exports run --profile "$AWS_PROFILE" --region "$REGION" --cluster "$CLUSTER_NAME" --export-id "$EXPORT_ID" --source-path "/exports/$EXPORT_ID/analysis_results/ubuntu/" --destination-s3-uri "$EXPORT_S3_URI"
+dyec --json exports attach --profile "$AWS_PROFILE" --region "$REGION" --cluster "$CLUSTER_NAME" --source-path "/fsx/analysis_results/ubuntu/$ANALYSIS_DIR" --destination-s3-uri "$EXPORT_S3_URI"
+dyec --json exports run --profile "$AWS_PROFILE" --region "$REGION" --source-path "/fsx/analysis_results/ubuntu/$ANALYSIS_DIR" --destination-s3-uri "$EXPORT_S3_URI" --fsx-file-system-id "$FSX_FILE_SYSTEM_ID"
 dyec --json exports detach --profile "$AWS_PROFILE" --region "$REGION" --association-id "$EXPORT_DRA_ID"
 ```
 

--- a/docs/dra_fsx_strategy.md
+++ b/docs/dra_fsx_strategy.md
@@ -9,9 +9,9 @@ This is the current DayEC data-plane model. FSx for Lustre is the high-performan
 | Reference data | `/fsx/data/` | `/data/` | `<reference-bucket>/data/` | Created with the cluster |
 | Run inputs | `/fsx/run_dir_mounts/<mount_id>/` | `/run_dir_mounts/<mount_id>/` | selected run prefix | Created and deleted on demand |
 | Workflow outputs | `/fsx/analysis_results/...` | `/analysis_results/...` | none by default | Local to the FSx filesystem until exported |
-| Export staging | `/fsx/exports/<export_id>/` | `/exports/<export_id>/` | selected analysis bucket/prefix | Temporary output DRA |
+| Direct analysis export | `/fsx/analysis_results/ubuntu/<analysis_dir>/` | `/analysis_results/ubuntu/<analysis_dir>/` | `s3://bucket/analysis_results/ubuntu/<analysis_dir>/` | Temporary output DRA |
 
-Run-directory DRAs are read-oriented by default. They configure AutoImport events and no AutoExport policy. Export DRAs are created only for selected output payloads and are detached after the FSx export task completes.
+Run-directory DRAs are read-oriented by default. They configure AutoImport events and no AutoExport policy. Export DRAs are created directly on one completed analysis directory, run one explicit FSx export task, and are detached after the task completes.
 
 ## Cluster And Run Lifecycle
 
@@ -35,10 +35,10 @@ sequenceDiagram
   Op->>DyEC: workflow launch
   DyEC->>DayOA: start tmux workflow
   DayOA->>FSx: read /fsx/data and /fsx/run_dir_mounts
-  DayOA->>FSx: write /fsx/analysis_results
-  Op->>FSx: copy selected outputs to /fsx/exports/<export_id>
-  Op->>DyEC: export --destination-s3-uri
-  FSx-->>Out: EXPORT_TO_REPOSITORY task
+  DayOA->>FSx: write /fsx/analysis_results/ubuntu/<analysis_dir>
+  Op->>DyEC: export --source-path /fsx/analysis_results/ubuntu/<analysis_dir>
+  DyEC->>FSx: create temporary DRA at /analysis_results/ubuntu/<analysis_dir>/
+  FSx-->>Out: EXPORT_TO_REPOSITORY task to /analysis_results/ubuntu/<analysis_dir>/
   DyEC->>FSx: detach export DRA
   Op->>DyEC: delete after receipt verification
 ```
@@ -51,7 +51,7 @@ flowchart LR
     Ref["Reference bucket /data/"]
     RunA["Run bucket prefix RUN_A"]
     RunB["Run bucket prefix RUN_B"]
-    Analysis["Analysis bucket /exports/<export_id>/"]
+    Analysis["Analysis bucket /analysis_results/ubuntu/<analysis_dir>/"]
   end
 
   subgraph Lustre["FSx for Lustre mounted at /fsx"]
@@ -59,7 +59,7 @@ flowchart LR
     MntA["/fsx/run_dir_mounts/RUN_A"]
     MntB["/fsx/run_dir_mounts/RUN_B"]
     Results["/fsx/analysis_results/..."]
-    Export["/fsx/exports/<export_id>"]
+    Export["temporary DRA on /fsx/analysis_results/ubuntu/<analysis_dir>"]
   end
 
   Ref -->|reference DRA| Data
@@ -68,7 +68,7 @@ flowchart LR
   Data --> Results
   MntA --> Results
   MntB --> Results
-  Results -->|operator-selected copy| Export
+  Results -->|exact completed analysis dir| Export
   Export -->|FSx export task| Analysis
 ```
 
@@ -100,8 +100,9 @@ flowchart TB
 
 Export is not automatic writeback from the run mount or reference mount. The supported export flow is:
 
-1. choose the outputs under `/fsx/analysis_results/...`
-2. copy them into `/fsx/exports/<export_id>/...`
-3. run `dyec export --source-path /exports/<export_id>/... --destination-s3-uri s3://...`
-4. keep `fsx_export.yaml`
-5. delete the cluster only after the receipt shows `status: success` and `detached: true`
+1. choose one completed directory under `/fsx/analysis_results/ubuntu/<analysis_dir>`
+2. run `dyec export --source-path /fsx/analysis_results/ubuntu/<analysis_dir> --destination-s3-uri s3://bucket/analysis_results/ubuntu/<analysis_dir>/`
+3. keep `fsx_export.yaml`
+4. delete the cluster only after the receipt shows `status: success`, `task_lifecycle: SUCCEEDED`, and `detached: true`
+
+The bucket is always explicit. DayEC validates that the S3 key suffix matches the normalized source analysis directory and writes FSx task reports outside the exported prefix under `daylily-monitor/fsx-export/<analysis_dir>/...`.

--- a/docs/monitoring_and_troubleshooting.md
+++ b/docs/monitoring_and_troubleshooting.md
@@ -112,15 +112,14 @@ Run-state files live under `/home/ubuntu/daylily-runs/<session>/`.
 
 ## 7. Export Failures
 
-Export reads from `/exports/<export_id>/...` and writes through an explicit temporary output DRA.
+Export reads from one completed analysis directory and writes through an explicit temporary output DRA.
 
 ```bash
 dyec export \
   --profile "$AWS_PROFILE" \
   --region "$REGION" \
   --cluster "$CLUSTER_NAME" \
-  --export-id "$EXPORT_ID" \
-  --source-path "/exports/$EXPORT_ID/analysis_results/ubuntu/" \
+  --source-path "/fsx/analysis_results/ubuntu/$ANALYSIS_DIR" \
   --destination-s3-uri "$EXPORT_S3_URI" \
   --output-dir "$EXPORT_DIR"
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -176,14 +176,7 @@ squeue
 
 ## Export Results
 
-Export is a separate output DRA flow. It does not write back through the reference DRA or run-input DRA.
-
-On the headnode, copy selected outputs into `/fsx/exports/<export_id>/...`:
-
-```bash
-mkdir -p /fsx/exports/$EXPORT_ID/analysis_results/ubuntu/
-cp -a /fsx/analysis_results/ubuntu/<analysis-run-id>/ /fsx/exports/$EXPORT_ID/analysis_results/ubuntu/
-```
+Export is a separate output DRA flow. It does not write back through the reference DRA or run-input DRA. It attaches a temporary DRA directly to one completed analysis directory.
 
 From the operator machine:
 
@@ -192,8 +185,7 @@ dyec export \
   --profile "$AWS_PROFILE" \
   --region "$REGION" \
   --cluster "$CLUSTER_NAME" \
-  --export-id "$EXPORT_ID" \
-  --source-path "/exports/$EXPORT_ID/analysis_results/ubuntu/" \
+  --source-path "/fsx/analysis_results/ubuntu/$ANALYSIS_DIR" \
   --destination-s3-uri "$EXPORT_S3_URI" \
   --output-dir "$EXPORT_DIR"
 ```
@@ -204,7 +196,7 @@ Verify:
 cat "$EXPORT_DIR/fsx_export.yaml"
 ```
 
-Success means `status: success`, `detached: true`, and a completed FSx export task id.
+Success means `status: success`, `task_lifecycle: SUCCEEDED`, `detached: true`, `delete_data_in_file_system: false`, and a completed FSx export task id. The destination must be an explicit S3 URI ending in `analysis_results/ubuntu/<analysis_dir>/`.
 
 ## Delete
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,8 +10,7 @@ The current codebase is DRA-first:
 2. Cluster creation adds a `reference-data` DRA from the reference bucket `data/` prefix to FSx API path `/data/`, visible as `/fsx/data`.
 3. `dyec mounts create` can attach selected S3 run prefixes as ephemeral run DRAs under `/run_dir_mounts/<mount_id>`, visible as `/fsx/run_dir_mounts/<mount_id>`.
 4. `dyec workflow launch` starts DayOA work in tmux on the headnode and writes outputs under `/fsx/analysis_results/...`.
-5. Operators copy selected outputs to `/fsx/exports/<export_id>/...`.
-6. `dyec export` creates a temporary output DRA, runs an FSx `EXPORT_TO_REPOSITORY` task, writes `fsx_export.yaml`, and detaches the DRA.
+5. `dyec export` creates a temporary output DRA directly on `/fsx/analysis_results/ubuntu/<analysis_dir>`, runs an FSx `EXPORT_TO_REPOSITORY` task, writes `fsx_export.yaml`, and detaches the DRA.
 7. `dyec delete` tears down the cluster after export verification.
 
 ## Control Plane
@@ -43,9 +42,8 @@ The namespace is intentionally explicit:
 | `/fsx/data` | Reference data from the cluster-created reference DRA |
 | `/fsx/run_dir_mounts/<mount_id>` | Read-oriented run-folder input DRA |
 | `/fsx/analysis_results/...` | Workflow checkout and result workspace |
-| `/fsx/exports/<export_id>` | Temporary export staging namespace |
 
-Run-directory mounts are inputs. They do not define the export destination and are rejected as export sources. Export is a separate output DRA task from `/exports/<export_id>/...` to the requested S3 URI.
+Run-directory mounts are inputs. They do not define the export destination and are rejected as export sources. Export is a separate output DRA task from `/analysis_results/ubuntu/<analysis_dir>/` to the requested S3 URI ending in the same `analysis_results/ubuntu/<analysis_dir>/` suffix.
 
 ## Workflow Plane
 

--- a/docs/plans/direct_analysis_export_dra_ledger.md
+++ b/docs/plans/direct_analysis_export_dra_ledger.md
@@ -1,0 +1,60 @@
+# Direct Analysis-Directory DRA Export Ledger
+
+Date: 2026-05-18
+
+Controlling plan: user-provided "Direct Analysis-Directory DRA Export" in the execution thread.
+
+Ledger status protocol: `/Users/jmajor/.codex/docs/plan-ledger-workflow.md`
+
+## Gate 0 Inventory Freeze
+
+Gate 0 status: `SUCCESS`
+
+### Repository
+
+| Repo | Path | Branch | Baseline commit | Dirty state |
+|---|---|---|---|---|
+| DayEC | `/Users/jmajor/.codex/worktrees/dyec-fsx-dra-mounts/daylily-ephemeral-cluster` | `codex/direct-analysis-export-dra` | `40c390b8 Merge pull request #250 from Daylily-Informatics/codex/dyec-fsx-dra-mounts` | Clean before implementation: `git status --short --branch` -> `## codex/direct-analysis-export-dra`. |
+
+### Gate 0 Commands
+
+| Area | Command | Result |
+|---|---|---|
+| Git status | `git status --short --branch` | Clean branch `codex/direct-analysis-export-dra`. |
+| Git identity | `git rev-parse --show-toplevel && git branch --show-current && git rev-parse --short HEAD` | Root `/Users/jmajor/.codex/worktrees/dyec-fsx-dra-mounts/daylily-ephemeral-cluster`; branch `codex/direct-analysis-export-dra`; HEAD `40c390b8`. |
+| Instruction files | `find .. -name AGENTS.md -o -name CLAUDE.md -o -path '*/.agents/*' -o -path '*/.codex/*'` | Repo-local instruction surface: `../daylily-ephemeral-cluster/AGENTS.md`. |
+| Baseline focused tests | `source ./activate >/dev/null && python -m pytest tests/test_export.py tests/test_cli_registry_v2.py tests/test_ssm_e2e_runner.py tests/test_delete.py tests/test_packaged_defaults.py -q` | `128 passed`. |
+| Staging-export sweep | `rg -n "/fsx/exports|/exports/<export_id>|/exports/\\$EXPORT_ID|/exports/export-1|--export-id|export_id|EXPORT_ROOT|HEADNODE_EXPORT_ROOT" daylily_ec tests docs README.md README.md.bland bin config -S` | Active code, docs, wrappers, and tests use the `/fsx/exports/<export_id>` staging-copy model and require `--export-id`. Historical plan ledgers also document the old model. |
+| Receipt/export sweep | `rg -n "schema_version: 2|EXPORT_SCHEMA_VERSION = 2|fsx_export|EXPORT_TO_REPOSITORY|DeleteDataInFileSystem" daylily_ec tests docs README.md README.md.bland bin -S` | Current export receipt schema is v2; export task and `DeleteDataInFileSystem=False` detach behavior are already present. |
+
+### Scope
+
+Active docs for this plan are `README.md`, `README.md.bland`, and direct `docs/*.md`. Historical plan ledgers and archive docs are not rewritten except for this new control ledger.
+
+No live AWS action is approved or required for implementation validation.
+
+## Rows
+
+| ID | Area | Requirement | Status | Category | Approval Gate | Owner | Evidence | Root Cause | Terminal Note |
+|---|---|---|---|---|---|---|---|---|---|
+| G0-001 | Planning | Record Gate 0 inventory before edits. | `SUCCESS` | `plan_amendment` | Gate 0 | orchestrator | This ledger. |  | Gate 0 recorded before implementation edits. |
+| EXP-001 | Workflow | Replace `/exports/<export_id>` staging DRA creation with direct analysis-directory DRA creation. | `SUCCESS` | `feature_implementation` | Gate 1 | orchestrator | `daylily_ec/workflow/export_data.py`; `tests/test_export.py`; focused suite `138 passed`; full suite `873 passed, 7 skipped`. |  | `dyec export` creates a DRA directly at `/analysis_results/ubuntu/<analysis_dir>/`, runs `EXPORT_TO_REPOSITORY`, and detaches. |
+| EXP-002 | Validation | Normalize source paths to `/analysis_results/ubuntu/<analysis_dir>/` and reject unsafe/non-analysis paths. | `SUCCESS` | `contract_test` | Gate 1 | orchestrator | `normalize_export_source_path`; `tests/test_export.py::test_normalize_export_source_accepts_analysis_dir`; `test_normalize_export_source_rejects_non_analysis_dir`. |  | Accepts `/fsx/analysis_results/ubuntu/foo` and `/analysis_results/ubuntu/foo/`; rejects run mounts, reference data, old export staging, nested paths, duplicate slashes, and `..`. |
+| EXP-003 | Validation | Require destination S3 suffix to match `analysis_results/ubuntu/<analysis_dir>/` with explicit bucket. | `SUCCESS` | `contract_test` | Gate 1 | orchestrator | `validate_export_destination_s3_uri`; `tests/test_export.py::test_validate_export_destination_requires_matching_suffix`. |  | Destination bucket remains explicit and key suffix must match the normalized analysis directory. |
+| EXP-004 | Receipt | Bump `fsx_export.yaml` to schema v3 with direct source, destination, task/report, failure, and detach details. | `SUCCESS` | `feature_implementation` | Gate 1 | orchestrator | `EXPORT_SCHEMA_VERSION = 3`; `daylily_ec/resources/payload/etc/fsx_export.yaml`; `tests/test_export.py::test_run_export_workflow_success_writes_v3_receipt`; task-failure and detach-failure tests. |  | Receipt records normalized source, destination, association id, task lifecycle, report path, detach state, fixed `delete_data_in_file_system: false`, and failure details. |
+| EXP-005 | Cleanup | Capture the temporary association id immediately after create so attach wait failures still detach and write a receipt. | `SUCCESS` | `legitimate_safety_handling` | Gate 1 | orchestrator | `daylily_ec/workflow/export_data.py`; `tests/test_export.py::test_run_export_workflow_attach_timeout_still_detaches`; focused command `source ./activate >/dev/null && python -m pytest tests/test_export.py tests/test_cli_registry_v2.py tests/test_ssm_e2e_runner.py tests/test_delete.py -q` -> `134 passed`. |  | A timeout while waiting for the DRA to become `AVAILABLE` records `association_id`, skips task creation, detaches with `DeleteDataInFileSystem=false`, and writes failure details. |
+| CLI-001 | CLI | Remove public `--export-id` requirement from primary `dyec export`; keep no public staging-copy mode. | `SUCCESS` | `removable_compatibility_debt` | Gate 1 | orchestrator | `daylily_ec/cli.py`; `tests/test_cli_registry_v2.py`; `tests/test_export.py::test_cli_export_passes_direct_analysis_options`. |  | Primary export requires `--source-path`, `--destination-s3-uri`, cluster or FSx id, region, and output dir. |
+| CLI-002 | CLI | Update or remove `dyec exports attach|run` so active public CLI does not preserve stale staging semantics; retain detach. | `SUCCESS` | `removable_compatibility_debt` | Gate 1 | orchestrator | `daylily_ec/cli.py`; `tests/test_cli_registry_v2.py`; focused suite `138 passed`. |  | `exports attach` and `exports run` now use direct `--source-path`; `exports detach --association-id` remains unchanged. |
+| WRAP-001 | Wrappers/E2E | Update packaged wrappers and SSM E2E runner export arguments for direct analysis-directory export. | `SUCCESS` | `feature_implementation` | Gate 1 | orchestrator | `bin/daylily-export-fsx-to-s3*`; packaged copies; `daylily_ec/ssh_to_ssm_e2e_runner.py`; wrapper `cmp` checks passed; `tests/test_ssm_e2e_runner.py`. |  | Wrappers no longer accept or forward export ids; E2E runner validates normalized source and explicit destination. |
+| DOC-001 | Docs | Remove active `/fsx/exports` guidance and document direct analysis-directory export flow. | `SUCCESS` | `feature_implementation` | Gate 2 | orchestrator | `README.md`; `README.md.bland`; direct `docs/*.md`; stale sweep `rg -n "export-id\|--export-id\|/fsx/exports\|/exports/<export_id>\|/exports/\\$EXPORT_ID\|/exports/export\|/exports/old" README.md README.md.bland docs/*.md bin daylily_ec/resources/payload/bin daylily_ec/resources/payload/etc -S` returned no hits. |  | Active docs show direct export from `/fsx/analysis_results/ubuntu/<analysis_dir>` to explicit `s3://bucket/analysis_results/ubuntu/<analysis_dir>/`. |
+| QA-001 | Validation | Run focused tests, full suite, ruff, stale sweeps, and `git diff --check`. | `SUCCESS` | `contract_test` | Gate 5 | orchestrator | Focused suite `134 passed`; full `python -m pytest -q` -> `874 passed, 7 skipped`; `ruff check` -> passed; `git diff --check` -> passed; stale schema sweep returned no hits; wrapper payload `cmp` checks passed. |  | Validation completed without live AWS actions. |
+
+## Status Counts
+
+- `SUCCESS`: 11
+- `OPEN`: 0
+- `BLOCKED`: 0
+- `NO_LONGER_NEEDED`: 0
+- `IN_PROGRESS`: 0
+- `ATTEMPTING_BUGFIX`: 0
+- `FAIL`: 0

--- a/docs/quickest_start.md
+++ b/docs/quickest_start.md
@@ -31,11 +31,11 @@ export CLUSTER_NAME=day-demo-$(date +%Y%m%d%H%M%S)
 export DAY_EX_CFG="$HOME/.config/daylily/daylily_ephemeral_cluster.yaml"
 export REF_BUCKET=s3://lsmc-dayoa-omics-analysis-us-west-2
 export ANALYSIS_BUCKET=s3://lsmc-dayoa-analysis-results-us-west-2
+export ANALYSIS_DIR=dayoa
 export ANALYSIS_SAMPLES=etc/analysis_samples_template.tsv
 export STAGE_CFG_DIR="$PWD/tmp-stage-config/$CLUSTER_NAME"
-export EXPORT_DIR="$PWD/tmp-export/$CLUSTER_NAME"
-export EXPORT_ID="${CLUSTER_NAME}-results"
-export EXPORT_S3_URI="$ANALYSIS_BUCKET/$EXPORT_ID/"
+export EXPORT_DIR="$PWD/tmp-export/$ANALYSIS_DIR"
+export EXPORT_S3_URI="$ANALYSIS_BUCKET/analysis_results/ubuntu/$ANALYSIS_DIR/"
 ```
 
 Sanity checks:
@@ -110,7 +110,7 @@ dyec workflow launch \
   --region "$REGION" \
   --cluster "$CLUSTER_NAME" \
   --stage-dir "/fsx/data/staged_sample_data/remote_stage_<timestamp>" \
-  --destination dayoa \
+  --destination "$ANALYSIS_DIR" \
   --git-tag 1.0.7
 ```
 
@@ -167,24 +167,16 @@ dyec workflow logs \
   --lines 50
 ```
 
-## 8. Export Selected Results
+## 8. Export Completed Analysis Directory
 
-Copy only selected outputs into the export namespace on the headnode:
-
-```bash
-mkdir -p /fsx/exports/$EXPORT_ID/analysis_results/ubuntu/
-cp -a /fsx/analysis_results/ubuntu/<analysis-run-id>/ /fsx/exports/$EXPORT_ID/analysis_results/ubuntu/
-```
-
-Then export from the operator machine:
+Export directly from the completed analysis directory on FSx:
 
 ```bash
 dyec export \
   --profile "$AWS_PROFILE" \
   --region "$REGION" \
   --cluster "$CLUSTER_NAME" \
-  --export-id "$EXPORT_ID" \
-  --source-path "/exports/$EXPORT_ID/analysis_results/ubuntu/" \
+  --source-path "/fsx/analysis_results/ubuntu/$ANALYSIS_DIR" \
   --destination-s3-uri "$EXPORT_S3_URI" \
   --output-dir "$EXPORT_DIR"
 
@@ -195,8 +187,9 @@ Expected receipt values:
 
 - `status: success`
 - `detached: true`
-- `source_path` under `/exports/<export_id>/`
-- `destination_s3_uri` matching the requested analysis bucket/prefix
+- `delete_data_in_file_system: false`
+- `source_path: /analysis_results/ubuntu/<analysis_dir>/`
+- `destination_s3_uri` matching `s3://bucket/analysis_results/ubuntu/<analysis_dir>/`
 
 ## 9. Delete
 

--- a/docs/ultra_rapid_start.md
+++ b/docs/ultra_rapid_start.md
@@ -12,11 +12,11 @@ export CLUSTER_NAME=day-demo-$(date +%Y%m%d%H%M%S)
 export DAY_EX_CFG="$HOME/.config/daylily/daylily_ephemeral_cluster.yaml"
 export REF_BUCKET=s3://lsmc-dayoa-omics-analysis-us-west-2
 export ANALYSIS_BUCKET=s3://lsmc-dayoa-analysis-results-us-west-2
+export ANALYSIS_DIR=dayoa
 export ANALYSIS_SAMPLES=etc/analysis_samples_template.tsv
 export STAGE_CFG_DIR="$PWD/tmp-stage-config/$CLUSTER_NAME"
-export EXPORT_DIR="$PWD/tmp-export/$CLUSTER_NAME"
-export EXPORT_ID="${CLUSTER_NAME}-results"
-export EXPORT_S3_URI="$ANALYSIS_BUCKET/$EXPORT_ID/"
+export EXPORT_DIR="$PWD/tmp-export/$ANALYSIS_DIR"
+export EXPORT_S3_URI="$ANALYSIS_BUCKET/analysis_results/ubuntu/$ANALYSIS_DIR/"
 
 dyec preflight --profile "$AWS_PROFILE" --region-az "$REGION_AZ" --config "$DAY_EX_CFG"
 dyec create --profile "$AWS_PROFILE" --region-az "$REGION_AZ" --config "$DAY_EX_CFG"
@@ -32,16 +32,14 @@ dyec workflow launch \
   --region "$REGION" \
   --cluster "$CLUSTER_NAME" \
   --stage-dir "/fsx/data/staged_sample_data/remote_stage_<timestamp>" \
-  --destination dayoa \
+  --destination "$ANALYSIS_DIR" \
   --git-tag 1.0.7
 
-# Copy selected outputs into /fsx/exports/$EXPORT_ID/... on the headnode first.
 dyec export \
   --profile "$AWS_PROFILE" \
   --region "$REGION" \
   --cluster "$CLUSTER_NAME" \
-  --export-id "$EXPORT_ID" \
-  --source-path "/exports/$EXPORT_ID/analysis_results/ubuntu/" \
+  --source-path "/fsx/analysis_results/ubuntu/$ANALYSIS_DIR" \
   --destination-s3-uri "$EXPORT_S3_URI" \
   --output-dir "$EXPORT_DIR"
 

--- a/tests/test_cli_registry_v2.py
+++ b/tests/test_cli_registry_v2.py
@@ -543,12 +543,10 @@ def test_export_command_passes_workflow_options(monkeypatch, tmp_path) -> None:
             "export",
             "--cluster-name",
             "cluster-a",
-            "--export-id",
-            "export-1",
             "--source-path",
-            "/exports/export-1/analysis_results/ubuntu/",
+            "/fsx/analysis_results/ubuntu/illumina_run_qc",
             "--destination-s3-uri",
-            "s3://bucket/exports/export-1/",
+            "s3://bucket/analysis_results/ubuntu/illumina_run_qc/",
             "--region",
             "us-west-2",
             "--output-dir",
@@ -563,9 +561,9 @@ def test_export_command_passes_workflow_options(monkeypatch, tmp_path) -> None:
     assert calls["verbose"] is True
     options = calls["options"]
     assert options.cluster_name == "cluster-a"
-    assert options.export_id == "export-1"
-    assert options.source_path == "/exports/export-1/analysis_results/ubuntu/"
-    assert options.destination_s3_uri == "s3://bucket/exports/export-1/"
+    assert not hasattr(options, "export_id")
+    assert options.source_path == "/fsx/analysis_results/ubuntu/illumina_run_qc"
+    assert options.destination_s3_uri == "s3://bucket/analysis_results/ubuntu/illumina_run_qc/"
     assert options.region == "us-west-2"
     assert options.profile == "dev"
     assert options.output_dir == tmp_path.resolve()

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -98,8 +98,8 @@ class TestDeleteHelpers:
                 },
                 {
                     "AssociationId": "dra-old",
-                    "FileSystemPath": "/exports/old/",
-                    "DataRepositoryPath": "s3://bucket/old/",
+                    "FileSystemPath": "/analysis_results/ubuntu/old/",
+                    "DataRepositoryPath": "s3://bucket/analysis_results/ubuntu/old/",
                     "Lifecycle": "DELETED",
                 },
             ]
@@ -110,7 +110,7 @@ class TestDeleteHelpers:
                     "TaskId": "task-1",
                     "Type": "EXPORT_TO_REPOSITORY",
                     "Lifecycle": "EXECUTING",
-                    "Paths": ["/exports/export-1/results/"],
+                    "Paths": ["/analysis_results/ubuntu/export_1/"],
                 },
                 {
                     "TaskId": "task-2",
@@ -248,7 +248,7 @@ class TestDeleteWorkflow:
             "export_tasks": [
                 {
                     "task_id": "task-1",
-                    "paths": ["/exports/export-1/results/"],
+                    "paths": ["/analysis_results/ubuntu/export_1/"],
                     "lifecycle": "EXECUTING",
                 }
             ],

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,4 +1,4 @@
-"""Tests for explicit FSx DRA export workflow and CLI."""
+"""Tests for direct analysis-directory FSx DRA export workflow and CLI."""
 
 from __future__ import annotations
 
@@ -14,8 +14,9 @@ from daylily_ec.workflow.export_data import (
     ExportOptions,
     attach_export_dra,
     normalize_export_source_path,
-    run_export_workflow,
     run_export_task,
+    run_export_workflow,
+    validate_export_destination_s3_uri,
 )
 
 runner = CliRunner()
@@ -36,12 +37,21 @@ def _filesystem() -> dict[str, object]:
 
 
 class FakeFsxClient:
-    def __init__(self, *, task_lifecycle: str = "SUCCEEDED", detach_fails: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        task_lifecycle: str = "SUCCEEDED",
+        detach_fails: bool = False,
+        association_lifecycle: str = "AVAILABLE",
+        existing_associations: list[dict[str, Any]] | None = None,
+    ) -> None:
         self.task_lifecycle = task_lifecycle
         self.detach_fails = detach_fails
+        self.association_lifecycle = association_lifecycle
         self.created_association: dict[str, Any] | None = None
         self.created_task: dict[str, Any] | None = None
         self.deleted_association_id: str | None = None
+        self.existing_associations = existing_associations or []
 
     def describe_file_systems(self, **params: Any) -> dict[str, Any]:
         wanted = set(params.get("FileSystemIds") or [])
@@ -62,14 +72,22 @@ class FakeFsxClient:
         }
 
     def describe_data_repository_associations(self, **params: Any) -> dict[str, Any]:
-        lifecycle = "DELETED" if self.deleted_association_id == "dra-export" else "AVAILABLE"
+        if params.get("Filters"):
+            return {"Associations": list(self.existing_associations)}
+        lifecycle = (
+            "DELETED"
+            if self.deleted_association_id == "dra-export"
+            else self.association_lifecycle
+        )
         return {
             "Associations": [
                 {
                     "AssociationId": "dra-export",
                     "FileSystemId": "fs-123",
-                    "FileSystemPath": "/exports/export-1/",
-                    "DataRepositoryPath": "s3://bucket/exports/export-1/",
+                    "FileSystemPath": "/analysis_results/ubuntu/illumina_run_qc/",
+                    "DataRepositoryPath": (
+                        "s3://bucket/analysis_results/ubuntu/illumina_run_qc/"
+                    ),
                     "Lifecycle": lifecycle,
                 }
             ]
@@ -112,22 +130,56 @@ class FakeSession:
         return self._client
 
 
-def test_normalize_export_source_rejects_run_mounts() -> None:
-    with pytest.raises(RuntimeError, match="Run-directory mounts"):
-        normalize_export_source_path(
-            "/fsx/run_dir_mounts/RUN123/fastqs/",
-            export_id="export-1",
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("/fsx/analysis_results/ubuntu/illumina_run_qc", "/analysis_results/ubuntu/illumina_run_qc/"),
+        ("/analysis_results/ubuntu/illumina_run_qc/", "/analysis_results/ubuntu/illumina_run_qc/"),
+    ],
+)
+def test_normalize_export_source_accepts_analysis_dir(raw: str, expected: str) -> None:
+    assert normalize_export_source_path(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "/fsx/exports/export-1/",
+        "/fsx/run_dir_mounts/RUN123/fastqs/",
+        "/fsx/data/cached_envs/",
+        "/analysis_results/ubuntu/illumina_run_qc/nested/",
+        "/analysis_results/ubuntu/../illumina_run_qc/",
+        "/analysis_results/ubuntu//illumina_run_qc/",
+    ],
+)
+def test_normalize_export_source_rejects_non_analysis_dir(raw: str) -> None:
+    with pytest.raises(RuntimeError):
+        normalize_export_source_path(raw)
+
+
+def test_validate_export_destination_requires_matching_suffix() -> None:
+    assert (
+        validate_export_destination_s3_uri(
+            "s3://bucket/analysis_results/ubuntu/illumina_run_qc",
+            source_path="/fsx/analysis_results/ubuntu/illumina_run_qc",
+        )
+        == "s3://bucket/analysis_results/ubuntu/illumina_run_qc/"
+    )
+    with pytest.raises(RuntimeError, match="destination_s3_uri must end with"):
+        validate_export_destination_s3_uri(
+            "s3://bucket/analysis_results/ubuntu/other/",
+            source_path="/fsx/analysis_results/ubuntu/illumina_run_qc",
         )
 
 
-def test_attach_export_dra_uses_no_auto_export_policy() -> None:
+def test_attach_export_dra_uses_analysis_dir_without_auto_export_policy() -> None:
     fake = FakeFsxClient()
 
     record = attach_export_dra(
         cluster_name="alpha",
         fsx_file_system_id="fs-123",
-        export_id="export-1",
-        destination_s3_uri="s3://bucket/exports/export-1",
+        source_path="/fsx/analysis_results/ubuntu/illumina_run_qc",
+        destination_s3_uri="s3://bucket/analysis_results/ubuntu/illumina_run_qc",
         region="us-west-2",
         profile="prof",
         wait=True,
@@ -136,21 +188,49 @@ def test_attach_export_dra_uses_no_auto_export_policy() -> None:
     )
 
     assert record.association_id == "dra-export"
+    assert record.analysis_dir == "illumina_run_qc"
     assert fake.created_association is not None
-    assert fake.created_association["FileSystemPath"] == "/exports/export-1/"
-    assert fake.created_association["DataRepositoryPath"] == "s3://bucket/exports/export-1/"
+    assert fake.created_association["FileSystemPath"] == "/analysis_results/ubuntu/illumina_run_qc/"
+    assert (
+        fake.created_association["DataRepositoryPath"]
+        == "s3://bucket/analysis_results/ubuntu/illumina_run_qc/"
+    )
     assert fake.created_association["BatchImportMetaDataOnCreate"] is False
     assert "S3" not in fake.created_association
 
 
-def test_run_export_task_starts_explicit_path_and_report() -> None:
+def test_attach_export_dra_rejects_overlapping_existing_dra() -> None:
+    fake = FakeFsxClient(
+        existing_associations=[
+            {
+                "AssociationId": "dra-existing",
+                "FileSystemPath": "/analysis_results/ubuntu/illumina_run_qc/",
+                "Lifecycle": "AVAILABLE",
+            }
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="overlaps existing"):
+        attach_export_dra(
+            cluster_name="alpha",
+            fsx_file_system_id="fs-123",
+            source_path="/fsx/analysis_results/ubuntu/illumina_run_qc",
+            destination_s3_uri="s3://bucket/analysis_results/ubuntu/illumina_run_qc",
+            region="us-west-2",
+            profile="prof",
+            wait=True,
+            timeout_seconds=1,
+            fsx_client=fake,
+        )
+
+
+def test_run_export_task_starts_exact_analysis_path_and_report() -> None:
     fake = FakeFsxClient()
 
     payload = run_export_task(
         fsx_file_system_id="fs-123",
-        export_id="export-1",
-        source_path="/exports/export-1/analysis_results/",
-        destination_s3_uri="s3://bucket/exports/export-1/",
+        source_path="/analysis_results/ubuntu/illumina_run_qc/",
+        destination_s3_uri="s3://bucket/analysis_results/ubuntu/illumina_run_qc/",
         wait=True,
         timeout_seconds=1,
         fsx_client=fake,
@@ -160,11 +240,14 @@ def test_run_export_task_starts_explicit_path_and_report() -> None:
     assert payload["task_lifecycle"] == "SUCCEEDED"
     assert fake.created_task is not None
     assert fake.created_task["Type"] == "EXPORT_TO_REPOSITORY"
-    assert fake.created_task["Paths"] == ["/exports/export-1/analysis_results/"]
-    assert fake.created_task["Report"]["Path"].startswith("s3://bucket/exports/export-1/")
+    assert fake.created_task["Paths"] == ["/analysis_results/ubuntu/illumina_run_qc/"]
+    assert fake.created_task["Report"]["Path"].startswith(
+        "s3://bucket/daylily-monitor/fsx-export/illumina_run_qc/"
+    )
+    assert "/analysis_results/ubuntu/illumina_run_qc/" not in fake.created_task["Report"]["Path"]
 
 
-def test_run_export_workflow_success_writes_full_receipt(tmp_path, monkeypatch) -> None:
+def test_run_export_workflow_success_writes_v3_receipt(tmp_path, monkeypatch) -> None:
     fake = FakeFsxClient()
     monkeypatch.setattr(
         "daylily_ec.workflow.export_data._create_session",
@@ -175,9 +258,8 @@ def test_run_export_workflow_success_writes_full_receipt(tmp_path, monkeypatch) 
         ExportOptions(
             cluster_name="alpha",
             fsx_file_system_id="fs-123",
-            export_id="export-1",
-            source_path="/exports/export-1/analysis_results/",
-            destination_s3_uri="s3://bucket/exports/export-1/",
+            source_path="/fsx/analysis_results/ubuntu/illumina_run_qc",
+            destination_s3_uri="s3://bucket/analysis_results/ubuntu/illumina_run_qc/",
             region="us-west-2",
             profile="prof",
             output_dir=tmp_path,
@@ -187,13 +269,18 @@ def test_run_export_workflow_success_writes_full_receipt(tmp_path, monkeypatch) 
     assert rc == 0
     payload = yaml.safe_load((tmp_path / "fsx_export.yaml").read_text(encoding="utf-8"))
     receipt = payload["fsx_export"]
-    assert receipt["schema_version"] == 2
+    assert receipt["schema_version"] == 3
     assert receipt["status"] == "success"
+    assert receipt["analysis_dir"] == "illumina_run_qc"
+    assert receipt["source_path"] == "/analysis_results/ubuntu/illumina_run_qc/"
+    assert receipt["headnode_path"] == "/fsx/analysis_results/ubuntu/illumina_run_qc/"
+    assert receipt["destination_s3_uri"] == "s3://bucket/analysis_results/ubuntu/illumina_run_qc/"
     assert receipt["fsx_file_system_id"] == "fs-123"
     assert receipt["association_id"] == "dra-export"
     assert receipt["task_id"] == "task-123"
     assert receipt["task_lifecycle"] == "SUCCEEDED"
     assert receipt["detached"] is True
+    assert receipt["delete_data_in_file_system"] is False
     assert fake.deleted_association_id == "dra-export"
 
 
@@ -208,9 +295,8 @@ def test_run_export_workflow_task_failure_still_detaches(tmp_path, monkeypatch) 
         ExportOptions(
             cluster_name="alpha",
             fsx_file_system_id="fs-123",
-            export_id="export-1",
-            source_path="/exports/export-1/analysis_results/",
-            destination_s3_uri="s3://bucket/exports/export-1/",
+            source_path="/fsx/analysis_results/ubuntu/illumina_run_qc",
+            destination_s3_uri="s3://bucket/analysis_results/ubuntu/illumina_run_qc/",
             region="us-west-2",
             profile="prof",
             output_dir=tmp_path,
@@ -221,10 +307,76 @@ def test_run_export_workflow_task_failure_still_detaches(tmp_path, monkeypatch) 
     payload = yaml.safe_load((tmp_path / "fsx_export.yaml").read_text(encoding="utf-8"))
     assert payload["fsx_export"]["status"] == "error"
     assert payload["fsx_export"]["detached"] is True
+    assert payload["fsx_export"]["failure_details"]["task_failure_details"] == {
+        "Message": "boom"
+    }
     assert fake.deleted_association_id == "dra-export"
 
 
-def test_cli_export_passes_explicit_dra_options(tmp_path, monkeypatch):
+def test_run_export_workflow_attach_timeout_still_detaches(tmp_path, monkeypatch) -> None:
+    fake = FakeFsxClient(association_lifecycle="CREATING")
+    monkeypatch.setattr(
+        "daylily_ec.workflow.export_data._create_session",
+        lambda _region, _profile: FakeSession(fake),
+    )
+
+    rc = run_export_workflow(
+        ExportOptions(
+            cluster_name="alpha",
+            fsx_file_system_id="fs-123",
+            source_path="/fsx/analysis_results/ubuntu/illumina_run_qc",
+            destination_s3_uri="s3://bucket/analysis_results/ubuntu/illumina_run_qc/",
+            region="us-west-2",
+            profile="prof",
+            output_dir=tmp_path,
+            timeout_seconds=0,
+        )
+    )
+
+    assert rc == 1
+    receipt = yaml.safe_load((tmp_path / "fsx_export.yaml").read_text(encoding="utf-8"))[
+        "fsx_export"
+    ]
+    assert receipt["status"] == "error"
+    assert receipt["association_id"] == "dra-export"
+    assert receipt["detached"] is True
+    assert receipt["failure_details"]["message"].startswith(
+        "Timed out waiting for FSx data repository association dra-export"
+    )
+    assert fake.created_task is None
+    assert fake.deleted_association_id == "dra-export"
+
+
+def test_run_export_workflow_detach_failure_surfaces_association(tmp_path, monkeypatch) -> None:
+    fake = FakeFsxClient(detach_fails=True)
+    monkeypatch.setattr(
+        "daylily_ec.workflow.export_data._create_session",
+        lambda _region, _profile: FakeSession(fake),
+    )
+
+    rc = run_export_workflow(
+        ExportOptions(
+            cluster_name="alpha",
+            fsx_file_system_id="fs-123",
+            source_path="/fsx/analysis_results/ubuntu/illumina_run_qc",
+            destination_s3_uri="s3://bucket/analysis_results/ubuntu/illumina_run_qc/",
+            region="us-west-2",
+            profile="prof",
+            output_dir=tmp_path,
+        )
+    )
+
+    assert rc == 1
+    receipt = yaml.safe_load((tmp_path / "fsx_export.yaml").read_text(encoding="utf-8"))[
+        "fsx_export"
+    ]
+    assert receipt["association_id"] == "dra-export"
+    assert receipt["status"] == "error"
+    assert receipt["detached"] is False
+    assert receipt["failure_details"]["message"] == "detach failed"
+
+
+def test_cli_export_passes_direct_analysis_options(tmp_path, monkeypatch):
     from daylily_ec.cli import app
 
     _activate_dayec_runtime(monkeypatch)
@@ -238,12 +390,10 @@ def test_cli_export_passes_explicit_dra_options(tmp_path, monkeypatch):
                 "export",
                 "--cluster-name",
                 "alpha",
-                "--export-id",
-                "export-1",
                 "--source-path",
-                "/exports/export-1/analysis_results/",
+                "/fsx/analysis_results/ubuntu/illumina_run_qc",
                 "--destination-s3-uri",
-                "s3://bucket/exports/export-1/",
+                "s3://bucket/analysis_results/ubuntu/illumina_run_qc/",
                 "--region",
                 "us-west-2",
                 "--output-dir",
@@ -258,9 +408,9 @@ def test_cli_export_passes_explicit_dra_options(tmp_path, monkeypatch):
     mock_logging.assert_called_once_with(True)
     options = mock_run.call_args.args[0]
     assert options.cluster_name == "alpha"
-    assert options.export_id == "export-1"
-    assert options.source_path == "/exports/export-1/analysis_results/"
-    assert options.destination_s3_uri == "s3://bucket/exports/export-1/"
+    assert not hasattr(options, "export_id")
+    assert options.source_path == "/fsx/analysis_results/ubuntu/illumina_run_qc"
+    assert options.destination_s3_uri == "s3://bucket/analysis_results/ubuntu/illumina_run_qc/"
     assert options.region == "us-west-2"
     assert options.profile == "prof"
     assert options.output_dir == Path(tmp_path).resolve()

--- a/tests/test_ssm_e2e_runner.py
+++ b/tests/test_ssm_e2e_runner.py
@@ -162,15 +162,15 @@ def test_record_step_writes_machine_readable_summary(tmp_path: Path) -> None:
 def _write_success_export_receipt(path: Path) -> None:
     path.write_text(
         "fsx_export:\n"
-        "  schema_version: 2\n"
+        "  schema_version: 3\n"
         "  status: success\n"
         "  fsx_file_system_id: fs-123\n"
         "  association_id: dra-export\n"
         "  task_id: task-123\n"
         "  task_lifecycle: SUCCEEDED\n"
         "  detached: true\n"
-        "  source_path: /exports/export-1/analysis_results/ubuntu/\n"
-        "  destination_s3_uri: s3://bucket/exports/export-1/\n",
+        "  source_path: /analysis_results/ubuntu/illumina_run_qc/\n"
+        "  destination_s3_uri: s3://bucket/analysis_results/ubuntu/illumina_run_qc/\n",
         encoding="utf-8",
     )
 
@@ -181,8 +181,8 @@ def test_validate_export_artifact_requires_success_and_expected_target(tmp_path:
 
     payload = runner_module._validate_export_artifact(
         export_yaml,
-        expected_source_path="/exports/export-1/analysis_results/ubuntu/",
-        expected_destination_s3_uri="s3://bucket/exports/export-1/",
+        expected_source_path="/fsx/analysis_results/ubuntu/illumina_run_qc",
+        expected_destination_s3_uri="s3://bucket/analysis_results/ubuntu/illumina_run_qc/",
     )
 
     assert payload["status"] == "success"
@@ -425,12 +425,10 @@ def test_main_runs_supported_lifecycle_and_writes_summary(monkeypatch, tmp_path:
             str(analysis_samples),
             "--export-output-dir",
             str(export_dir),
-            "--export-id",
-            "export-1",
             "--export-source-path",
-            "/exports/export-1/analysis_results/ubuntu/",
+            "/analysis_results/ubuntu/illumina_run_qc/",
             "--export-destination-s3-uri",
-            "s3://bucket/exports/export-1/",
+            "s3://bucket/analysis_results/ubuntu/illumina_run_qc/",
             "--output-json",
             str(output_json),
             "--workflow-live",
@@ -563,12 +561,10 @@ def test_main_reuses_existing_cluster_and_skips_create(monkeypatch, tmp_path: Pa
             str(analysis_samples),
             "--export-output-dir",
             str(export_dir),
-            "--export-id",
-            "export-1",
             "--export-source-path",
-            "/exports/export-1/analysis_results/ubuntu/",
+            "/analysis_results/ubuntu/illumina_run_qc/",
             "--export-destination-s3-uri",
-            "s3://bucket/exports/export-1/",
+            "s3://bucket/analysis_results/ubuntu/illumina_run_qc/",
             "--output-json",
             str(output_json),
             "--workflow-live",
@@ -669,12 +665,10 @@ def test_main_passes_custom_workflow_launch_arguments(monkeypatch, tmp_path: Pat
             str(analysis_samples),
             "--export-output-dir",
             str(export_dir),
-            "--export-id",
-            "export-1",
             "--export-source-path",
-            "/exports/export-1/analysis_results/ubuntu/",
+            "/analysis_results/ubuntu/illumina_run_qc/",
             "--export-destination-s3-uri",
-            "s3://bucket/exports/export-1/",
+            "s3://bucket/analysis_results/ubuntu/illumina_run_qc/",
             "--output-json",
             str(output_json),
             "--workflow-live",


### PR DESCRIPTION
## Summary
- replace the `/fsx/exports/<export_id>` staging-copy flow with direct temporary export DRAs on completed analysis directories
- require explicit `--source-path` and `--destination-s3-uri` matching `/analysis_results/ubuntu/<analysis_dir>/`
- update wrappers, SSM E2E runner arguments, active docs, and ledger evidence for the direct export workflow
- capture the DRA association id immediately after create so attach wait failures still detach with `DeleteDataInFileSystem=false` and write a receipt

## Validation
- `source ./activate >/dev/null && python -m pytest tests/test_export.py tests/test_cli_registry_v2.py tests/test_ssm_e2e_runner.py tests/test_delete.py -q` -> 134 passed
- `source ./activate >/dev/null && python -m pytest -q` -> 874 passed, 7 skipped
- `source ./activate >/dev/null && ruff check` -> passed
- `git diff --check` -> passed
- active docs/wrappers stale `/fsx/exports` sweep -> no hits
- wrapper payload `cmp` checks -> passed

## Live note
A live export attempt against `dra-test4` was killed on request while the temporary association was still `CREATING`; no export task started and no receipt was written from that attempt.
