### PR TITLE
[codex] Record DayOA release and ILMN cleanup ledgers

### DIFF
--- a/config/daylily_available_repositories.yaml
+++ b/config/daylily_available_repositories.yaml
@@ -99,7 +99,7 @@ repositories:
     description: "Primary whole genome and multiomics workflows."
     https_url: https://github.com/Daylily-Informatics/daylily-omics-analysis.git
     ssh_url: git@github.com:Daylily-Informatics/daylily-omics-analysis.git
-    default_ref: 1.0.12
+    default_ref: 1.0.15
     relative_path: daylily-omics-analysis
     analysis_commands:
       - command_id: illumina_snv_alignstats
@@ -137,7 +137,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - ilmn_solo
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: illumina_snv_alignstats_relatedness_vep_multiqc
         display_name: "Illumina SNV + Alignstats + Relatedness + VEP MultiQC"
@@ -177,7 +177,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - ilmn_solo
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: ultima_snv_alignstats
         display_name: "Ultima SNV + Alignstats"
@@ -213,7 +213,7 @@ repositories:
           - ULTIMA
         compatible_data_modes:
           - ultima_solo
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: ont_snv_alignstats
         display_name: "ONT SNV + Alignstats"
@@ -250,7 +250,7 @@ repositories:
           - ONT
         compatible_data_modes:
           - ont_solo
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: pacbio_snv_alignstats
         display_name: "PacBio SNV + Alignstats"
@@ -287,7 +287,7 @@ repositories:
           - PACBIO
         compatible_data_modes:
           - pacbio_solo
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: roche_snv_alignstats
         display_name: "Roche SNV + Alignstats"
@@ -323,7 +323,7 @@ repositories:
           - ROCHE
         compatible_data_modes:
           - roche_solo
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: hybrid_ilmn_ont_snv
         display_name: "Hybrid ILMN+ONT SNV/SV"
@@ -363,7 +363,7 @@ repositories:
           - ONT
         compatible_data_modes:
           - hybrid_ilmn_ont
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: hybrid_ultima_ont_snv
         display_name: "Hybrid Ultima+ONT SNV"
@@ -403,7 +403,7 @@ repositories:
           - ONT
         compatible_data_modes:
           - hybrid_ug_ont
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: complete_genomics_mgi_snv_concordance
         display_name: "Complete Genomics/MGI SNV + Concordance"
@@ -440,7 +440,7 @@ repositories:
           - CG/MGI
         compatible_data_modes:
           - complete_genomics_solo
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: illumina_run_qc
         display_name: "Illumina Run QC"
@@ -470,7 +470,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: illumina_bclconvert
         display_name: "Illumina BCL Convert"
@@ -500,7 +500,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: ont_run_qc
         display_name: "ONT Run QC"
@@ -530,7 +530,7 @@ repositories:
           - ONT
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: ultima_run_qc
         display_name: "Ultima Run QC"
@@ -560,7 +560,7 @@ repositories:
           - ULTIMA
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
   rna-seq-star-deseq2:
     display_name: "RNA-seq STAR + DESeq2"

--- a/config/daylily_cli_global.yaml
+++ b/config/daylily_cli_global.yaml
@@ -1,7 +1,7 @@
 ---
 daylily:
-  git_ephemeral_cluster_repo_tag: 4.0.6
-  git_ephemeral_cluster_repo_release_tag: 4.0.6
+  git_ephemeral_cluster_repo_tag: 4.0.7
+  git_ephemeral_cluster_repo_release_tag: 4.0.7
   git_ephemeral_cluster_repo: https://github.com/Daylily-Informatics/daylily-ephemeral-cluster.git
   analysis_root: /fsx/analysis_results/
   sentieon_lic_path: /fsx/data/cached_envs/x.lic

--- a/daylily_ec/resources/payload/config/daylily_available_repositories.yaml
+++ b/daylily_ec/resources/payload/config/daylily_available_repositories.yaml
@@ -99,7 +99,7 @@ repositories:
     description: "Primary whole genome and multiomics workflows."
     https_url: https://github.com/Daylily-Informatics/daylily-omics-analysis.git
     ssh_url: git@github.com:Daylily-Informatics/daylily-omics-analysis.git
-    default_ref: 1.0.12
+    default_ref: 1.0.15
     relative_path: daylily-omics-analysis
     analysis_commands:
       - command_id: illumina_snv_alignstats
@@ -137,7 +137,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - ilmn_solo
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: illumina_snv_alignstats_relatedness_vep_multiqc
         display_name: "Illumina SNV + Alignstats + Relatedness + VEP MultiQC"
@@ -177,7 +177,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - ilmn_solo
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: ultima_snv_alignstats
         display_name: "Ultima SNV + Alignstats"
@@ -213,7 +213,7 @@ repositories:
           - ULTIMA
         compatible_data_modes:
           - ultima_solo
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: ont_snv_alignstats
         display_name: "ONT SNV + Alignstats"
@@ -250,7 +250,7 @@ repositories:
           - ONT
         compatible_data_modes:
           - ont_solo
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: pacbio_snv_alignstats
         display_name: "PacBio SNV + Alignstats"
@@ -287,7 +287,7 @@ repositories:
           - PACBIO
         compatible_data_modes:
           - pacbio_solo
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: roche_snv_alignstats
         display_name: "Roche SNV + Alignstats"
@@ -323,7 +323,7 @@ repositories:
           - ROCHE
         compatible_data_modes:
           - roche_solo
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: hybrid_ilmn_ont_snv
         display_name: "Hybrid ILMN+ONT SNV/SV"
@@ -363,7 +363,7 @@ repositories:
           - ONT
         compatible_data_modes:
           - hybrid_ilmn_ont
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: hybrid_ultima_ont_snv
         display_name: "Hybrid Ultima+ONT SNV"
@@ -403,7 +403,7 @@ repositories:
           - ONT
         compatible_data_modes:
           - hybrid_ug_ont
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: complete_genomics_mgi_snv_concordance
         display_name: "Complete Genomics/MGI SNV + Concordance"
@@ -440,7 +440,7 @@ repositories:
           - CG/MGI
         compatible_data_modes:
           - complete_genomics_solo
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: illumina_run_qc
         display_name: "Illumina Run QC"
@@ -470,7 +470,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: illumina_bclconvert
         display_name: "Illumina BCL Convert"
@@ -500,7 +500,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: ont_run_qc
         display_name: "ONT Run QC"
@@ -530,7 +530,7 @@ repositories:
           - ONT
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
       - command_id: ultima_run_qc
         display_name: "Ultima Run QC"
@@ -560,7 +560,7 @@ repositories:
           - ULTIMA
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 1.0.12
+        git_tag: 1.0.15
         no_containerized: false
   rna-seq-star-deseq2:
     display_name: "RNA-seq STAR + DESeq2"

--- a/daylily_ec/resources/payload/config/daylily_cli_global.yaml
+++ b/daylily_ec/resources/payload/config/daylily_cli_global.yaml
@@ -1,7 +1,7 @@
 ---
 daylily:
-  git_ephemeral_cluster_repo_tag: 4.0.6
-  git_ephemeral_cluster_repo_release_tag: 4.0.6
+  git_ephemeral_cluster_repo_tag: 4.0.7
+  git_ephemeral_cluster_repo_release_tag: 4.0.7
   git_ephemeral_cluster_repo: https://github.com/Daylily-Informatics/daylily-ephemeral-cluster.git
   analysis_root: /fsx/analysis_results/
   sentieon_lic_path: /fsx/data/cached_envs/x.lic

--- a/docs/plans/20260519T061830Z_ilmn0006_multiqc_1013_dryrun_ledger.md
+++ b/docs/plans/20260519T061830Z_ilmn0006_multiqc_1013_dryrun_ledger.md
@@ -1,0 +1,55 @@
+# ILMN 0006 DayOA 1.0.13 Final MultiQC Dry-Run Ledger
+
+Date opened: 2026-05-19T06:18:30Z
+
+## Control
+
+Controlling request: enter the existing ILMN 0006 headnode tmux run directory, run `git pull`, check out DayOA tag `1.0.13`, run `git pull` again, then dry-run final MultiQC generation with `--rerun-triggers mtime -n` to confirm the workflow will not rerun heavy upstream work.
+
+Ledger path: `/Users/jmajor/projects/daylily/daylily-ephemeral-cluster/docs/plans/20260519T061830Z_ilmn0006_multiqc_1013_dryrun_ledger.md`
+
+Execution scope:
+- Local repo: `/Users/jmajor/projects/daylily/daylily-ephemeral-cluster`
+- AWS profile: `lsmc`
+- AWS region: `us-west-2`
+- Cluster: `may26-d`
+- Headnode: `i-0e7639ff46f207ae7`
+- Tmux session: `ilmn_0006_align_dedup_alignstats_20260517T185626Z`
+- Run checkout: `/fsx/analysis_results/ubuntu/ilmn_0006_align_dedup_alignstats_20260517T185626Z/daylily-omics-analysis`
+- Run log dir: `/home/ubuntu/daylily-runs/ilmn_0006_align_dedup_alignstats_20260517T185626Z`
+
+Hard boundaries:
+- Dry-run only in this ledger.
+- Stop after dry-run review if planned jobs include alignment, DMD dedup, SNV calling, alignstats, or other unexpectedly heavy upstream reruns.
+- Preserve existing run-local dirty state before checking out `1.0.13`; do not reset or discard remote changes.
+- Use DayEC SSM helpers as `ubuntu`.
+
+## Gate 0 Baseline
+
+- Local repo status at open: `## codex/docs-plans-ledgers...origin/codex/docs-plans-ledgers` with pre-existing untracked artifacts, including `docs/ntc_and_other_analysis_bugs.md`, `tmp-export/`, and several 0007 index reports.
+- Headnode info: `daylily-ec --json headnode info --profile lsmc --region us-west-2 --cluster may26-d` returned cluster `CREATE_COMPLETE`, compute fleet `RUNNING`, headnode `i-0e7639ff46f207ae7`, private IP `10.0.0.121`.
+- Baseline SSM command: `9c053690-10a8-459c-acf4-30efd2b8f475`.
+- Baseline remote identity: `ubuntu@ip-10-0-0-121`.
+- Baseline checkout: detached `HEAD`, `git describe=1.0.7-dirty`, `HEAD=a9d6a5da0a2778f2dcd135f6455c1c752e43d40e`, dirty `workflow/rules/common.smk`, untracked `sbatch_errs.log`.
+- Baseline final report state: missing `results/day/hg38/reports/DAY_final_multiqc.html` and missing `results/day/hg38_broad/reports/DAY_final_multiqc.html`.
+- Baseline tmux state: session `ilmn_0006_align_dedup_alignstats_20260517T185626Z` exists; pane `0.0` is in the run checkout with command `bash`.
+- Baseline Slurm state: `squeue -u ubuntu` returned only the header; no active jobs.
+- Recent run logs show previous direct MultiQC attempts through `stage_multiqc_inputs_final_forced_20260518T150028Z.log` and `multiqc_final_wgs_direct_live_20260518T143202Z.log`, but no final report exists.
+
+## Control Ledger
+
+| ID | Area | Requirement | Status | Category | Approval Gate | Owner | Evidence | Root Cause | Terminal Note |
+|---|---|---|---|---|---|---|---|---|---|
+| G0-001 | DayEC/DayOA | Record local repo, headnode, tmux, Slurm, remote checkout, and final report baseline before mutation. | SUCCESS | contract_test | Gate 0 | orchestrator | Gate 0 Baseline section. |  | Baseline recorded before checkout/tag change. |
+| TAG-001 | DayOA headnode | In the existing run tmux session, run pre-checkout `git pull`, fetch/check out tag `1.0.13`, and run post-checkout `git pull` while preserving dirty state. | SUCCESS | feature_implementation | Gate 1 | orchestrator | Write attempt with long remote filename failed before mutation because AWS SSM comments are capped at 100 chars. Retry wrote `/home/ubuntu/daylily-runs/ilmn0006_mqc1013_20260519T062200Z.sh` with `write_remote_text` command `5f281ad4-e376-430f-9be0-034b66619257` and launched it in tmux with command `70321371-fd1e-41cb-8dec-4029f4b722ba`. Pre-checkout `git pull --ff-only` fetched tags `1.0.8` through `1.0.13` and returned rc `1` because the checkout was detached. Dirty state was preserved in `stash@{0}` with message `codex-before-1.0.13-ilmn0006-20260519T062200Z`. `git checkout 1.0.13` succeeded at `aef09db649edf7edd2d91d07851dd249f991fba2`; post-checkout `git pull --ff-only` returned rc `1` because the checkout is detached. Status: `/home/ubuntu/daylily-runs/ilmn_0006_align_dedup_alignstats_20260517T185626Z/multiqc_1013_dryrun_20260519T062200Z.status.json`. |  | Run checkout is at exact tag `1.0.13`; previous run-local dirty state was not discarded. |
+| MQC-DRYRUN-001 | DayOA headnode | Run `produce_multiqc_all -j 200 -p -k --rerun-triggers mtime -n` for ILMN 0006 at tag `1.0.13` with sent/dmd/sentd config. | BLOCKED | contract_test | Gate 2 | orchestrator | First dry-run attempt after checkout failed during activation: `dyoainit_rc=3`, `day_activate_rc=2`, because `USER` was unset. Retry with `USER/LOGNAME/HOME` set and sourced `./dyoainit --skip-project-check` successfully, but `bin/day_activate slurm hg38 remote` still failed with `DAY_ROOT is not set`; status `/home/ubuntu/daylily-runs/ilmn_0006_align_dedup_alignstats_20260517T185626Z/multiqc_1013_dryrun_retry_20260519T062600Z.status.json`. Final retry sourced run-local `./dyoainit --skip-project-check`, set the explicit slurm profile env, and ran `DAY_CONTAINERIZED=true bin/day_run produce_multiqc_all -j 200 -p -k --rerun-triggers mtime -n --config genome_build=hg38 "aligners=['sent']" "dedupers=['dmd']" "snv_callers=['sentd']" "sv_callers=[]"`. It reached Snakemake and failed with `SyntaxError in file .../workflow/rules/common.smk, line 1172: Expected name after module keyword.` Log: `/home/ubuntu/daylily-runs/ilmn_0006_align_dedup_alignstats_20260517T185626Z/multiqc_1013_manual_dryrun_20260519T063100Z.log`; status: `/home/ubuntu/daylily-runs/ilmn_0006_align_dedup_alignstats_20260517T185626Z/multiqc_1013_manual_dryrun_20260519T063100Z.status.json`, `dryrun_rc=1`. Operator correction was then applied exactly: `source ./dyoainit --skip-project-check` from the run checkout. This exact-path attempt had `dyoainit_rc=0`, `DAY_ROOT=/fsx/analysis_results/ubuntu/ilmn_0006_align_dedup_alignstats_20260517T185626Z/daylily-omics-analysis`, `profile_env_rc=0`, then failed at the same Snakemake syntax error. Log: `/home/ubuntu/daylily-runs/ilmn_0006_align_dedup_alignstats_20260517T185626Z/multiqc_1013_exact_dyoainit_dryrun_20260519T064000Z.log`; status: `/home/ubuntu/daylily-runs/ilmn_0006_align_dedup_alignstats_20260517T185626Z/multiqc_1013_exact_dyoainit_dryrun_20260519T064000Z.status.json`, `dryrun_rc=1`. | DayOA tag `1.0.13` has top-level Python variable assignment `module = importlib.util.module_from_spec(spec)` in `workflow/rules/common.smk`; Snakemake parses `module` as its directive keyword and aborts before DAG construction. | Dry-run command was attempted with exact `source ./dyoainit` and failed before any DAG/job table was produced. |
+| SAFETY-001 | DayOA headnode | Review dry-run job table and confirm whether alignment, DMD dedup, SNV calling, alignstats, or VEP reruns are planned. | BLOCKED | legitimate_safety_handling | Gate 3 | orchestrator | SSM status command `e6ced0d3-0b83-4573-97d3-1c16fe1e34fa` showed no runner process and `squeue -u ubuntu` returned only the header. Because Snakemake failed before DAG construction, there is no job table to inspect. | The `1.0.13` `common.smk` syntax error prevents DAG construction. | No work was submitted or rerun, but safety review cannot answer planned-job counts until the syntax error is fixed. |
+| FINAL-001 | DayEC/DayOA | Update ledger with terminal evidence and report whether it is safe to run the real final MultiQC command. | SUCCESS | contract_test | Gate 5 | orchestrator | Ledger rows updated with tag checkout, activation attempts, syntax failure, and empty Slurm evidence. |  | It is not safe to launch the real final MultiQC command from this checkout until the `common.smk` `module` variable bug is fixed and a clean dry-run produces an inspectable job table. |
+
+## Terminal Summary
+
+- Rows terminal: `5/5`.
+- Objective complete: no. The run checkout is at exact tag `1.0.13`, but final MultiQC dry-run is blocked before DAG construction by a `common.smk` syntax error in the tag.
+- Remote checkout state after this ledger: exact tag `1.0.13` at `aef09db649edf7edd2d91d07851dd249f991fba2`; pre-existing dirty state preserved in `stash@{0}`.
+- No real workflow was launched; no Slurm jobs were submitted during the dry-run attempts.
+- The exact-path activation evidence requested by the operator is in `/home/ubuntu/daylily-runs/ilmn_0006_align_dedup_alignstats_20260517T185626Z/multiqc_1013_exact_dyoainit_dryrun_20260519T064000Z.log`.

--- a/docs/plans/20260519T063749Z_ilmn0006_dayoa_fsx_export_ledger.md
+++ b/docs/plans/20260519T063749Z_ilmn0006_dayoa_fsx_export_ledger.md
@@ -1,0 +1,42 @@
+# ILMN 0006 DayOA Directory FSx-to-S3 Export Ledger
+
+Date opened: 2026-05-19T06:37:49Z
+
+## Control
+
+Controlling request: start an FSx-to-S3 export of the Illumina run 0006 DayOA directory and report back while the export runs in the background.
+
+Ledger path: `/Users/jmajor/projects/daylily/daylily-ephemeral-cluster/docs/plans/20260519T063749Z_ilmn0006_dayoa_fsx_export_ledger.md`
+
+Execution scope:
+- Local repo: `/Users/jmajor/projects/daylily/daylily-ephemeral-cluster`
+- AWS profile: `lsmc`
+- AWS region: `us-west-2`
+- Cluster: `may26-d`
+- FSx filesystem: `fs-0c43ddf4b70dc87d8`
+- Export method: AWS CLI single data-repository task, `EXPORT_TO_REPOSITORY`
+- FSx path: `analysis_results/ubuntu/ilmn_0006_align_dedup_alignstats_20260517T185626Z/daylily-omics-analysis`
+- Expected S3 URI: `s3://lsmc-dayoa-omics-analysis-us-west-2/FSxLustre20260515T103052Z/analysis_results/ubuntu/ilmn_0006_align_dedup_alignstats_20260517T185626Z/daylily-omics-analysis`
+
+## Gate 0 Baseline
+
+- Local repo status: `## codex/docs-plans-ledgers...origin/codex/docs-plans-ledgers` with existing untracked working artifacts.
+- Prior 0006 export evidence: `tmp-export/ilmn0006-full-repo-20260518T135640Z/fsx_export.yaml` exported parent path `analysis_results/ubuntu/ilmn_0006_align_dedup_alignstats_20260517T185626Z` to the same S3 root with FSx filesystem `fs-0c43ddf4b70dc87d8`.
+- User direction from prior ledger: use old-fashioned AWS CLI single-DRA export path rather than `daylily-ec export`.
+
+## Control Ledger
+
+| ID | Area | Requirement | Status | Category | Approval Gate | Owner | Evidence | Root Cause | Terminal Note |
+|---|---|---|---|---|---|---|---|---|---|
+| G0-001 | DayEC/AWS | Record export target, prior FSx/S3 mapping, local repo state, and user-directed export method. | SUCCESS | contract_test | Gate 0 | orchestrator | Gate 0 Baseline section. |  | Baseline recorded before live export task creation. |
+| EXP-001 | AWS FSx | Create asynchronous single-DRA FSx export task for the 0006 `daylily-omics-analysis` directory. | SUCCESS | feature_implementation | Gate 1 | orchestrator | AWS CLI `aws fsx create-data-repository-task --file-system-id fs-0c43ddf4b70dc87d8 --type EXPORT_TO_REPOSITORY --paths analysis_results/ubuntu/ilmn_0006_align_dedup_alignstats_20260517T185626Z/daylily-omics-analysis --report Enabled=true,Path=s3://lsmc-dayoa-omics-analysis-us-west-2/FSxLustre20260515T103052Z/daylily-monitor/20260519T063749Z/export-report,Format=REPORT_CSV_20191124,Scope=FAILED_FILES_ONLY` created task `task-09b26c2c4b85deb91`. Receipt dir: `tmp-export/ilmn0006-dayoa-dir-20260519T063749Z`. |  | Export task started asynchronously. |
+| STATUS-001 | AWS FSx | Capture initial task lifecycle/counts and report back without waiting for terminal completion. | SUCCESS | legitimate_safety_handling | Gate 1 | orchestrator | Initial describe: `PENDING`, counts `null`. Follow-up describe after 8 seconds: `EXECUTING`, `total=0`, `succeeded=0`, `failed=0`. |  | Task is running in the background; no terminal completion check was requested in this step. |
+
+## Current Export Status
+
+- Task id: `task-09b26c2c4b85deb91`
+- Lifecycle at last poll: `EXECUTING`
+- Export source path: `analysis_results/ubuntu/ilmn_0006_align_dedup_alignstats_20260517T185626Z/daylily-omics-analysis`
+- Expected S3 URI: `s3://lsmc-dayoa-omics-analysis-us-west-2/FSxLustre20260515T103052Z/analysis_results/ubuntu/ilmn_0006_align_dedup_alignstats_20260517T185626Z/daylily-omics-analysis`
+- Export report path: `s3://lsmc-dayoa-omics-analysis-us-west-2/FSxLustre20260515T103052Z/daylily-monitor/20260519T063749Z/export-report`
+- Local receipt directory: `tmp-export/ilmn0006-dayoa-dir-20260519T063749Z`

--- a/docs/plans/20260519T070647Z_ilmn0006_multiqc_1014_run_ledger.md
+++ b/docs/plans/20260519T070647Z_ilmn0006_multiqc_1014_run_ledger.md
@@ -1,0 +1,58 @@
+# ILMN 0006 DayOA 1.0.14 Final MultiQC Run Ledger
+
+Date opened: 2026-05-19T07:06:47Z
+
+## Control
+
+Controlling request: use the existing ILMN 0006 headnode tmux run directory, run `git pull`, check out DayOA tag `1.0.14`, run `git pull`, then attempt final MultiQC generation. If the run hits code problems, repair `/Users/jmajor/projects/daylily/daylily-omics-analysis`, commit and push, pull the fix into the headnode checkout, and continue until MultiQC runs. Do not allow alignment, DMD dedup, SNV calling, alignstats, or similar long-running upstream processes to restart.
+
+Ledger path: `/Users/jmajor/projects/daylily/daylily-ephemeral-cluster/docs/plans/20260519T070647Z_ilmn0006_multiqc_1014_run_ledger.md`
+
+Execution scope:
+- DayEC repo: `/Users/jmajor/projects/daylily/daylily-ephemeral-cluster`
+- DayOA repair repo: `/Users/jmajor/projects/daylily/daylily-omics-analysis`
+- AWS profile: `lsmc`
+- AWS region: `us-west-2`
+- Cluster: `may26-d`
+- Headnode: `i-0e7639ff46f207ae7`
+- Tmux session: `ilmn_0006_align_dedup_alignstats_20260517T185626Z`
+- Run checkout: `/fsx/analysis_results/ubuntu/ilmn_0006_align_dedup_alignstats_20260517T185626Z/daylily-omics-analysis`
+- Run log dir: `/home/ubuntu/daylily-runs/ilmn_0006_align_dedup_alignstats_20260517T185626Z`
+
+Hard boundaries:
+- A passing `--rerun-triggers mtime -n` dry-run with inspected job table is required before any real run.
+- Stop before real execution if the DAG includes `sentieon_bwa_sort`, `doppelmark_dups`, `sent_DNAscope`, `alignstats`, `finish_align_stats`, or other long-running upstream rules not expected for final report generation.
+- Use run-local `source ./dyoainit --skip-project-check` from the DayOA checkout.
+- Preserve existing remote dirty state before changing tags.
+
+## Gate 0 Baseline
+
+- DayEC local status: `## codex/docs-plans-ledgers...origin/codex/docs-plans-ledgers`, with pre-existing untracked artifacts and ledgers.
+- DayOA local status: `## main...origin/main`, with pre-existing untracked docs/plan artifacts.
+- Local tag `1.0.14` exists at `b6c5f802c8291c90eb52da58a982e449fc76fe8d`.
+- Previous `1.0.13` run checkout attempt failed before DAG construction with `SyntaxError ... common.smk, line 1172: Expected name after module keyword`.
+- Previous exact-path activation proof used `source ./dyoainit --skip-project-check` successfully and set `DAY_ROOT` for the remote run checkout.
+
+## Terminal Evidence
+
+- Final controller: `multiqc_safe_run_20260519T075425Z`.
+- Remote status file: `/home/ubuntu/daylily-runs/ilmn_0006_align_dedup_alignstats_20260517T185626Z/multiqc_safe_run_20260519T075425Z.status.json`.
+- Final status: `phase=success`, `dryrun_rc=0`, `live_rc=0`, `rc=0`, `finished_at=2026-05-19T08:14:33Z`.
+- Remote DayOA checkout at completion: `git_describe=1.0.14-7-g040f012`, `git_head=040f0123248ee6e9d4e8132a4c92d8bb492368a8`.
+- Final report: `/fsx/analysis_results/ubuntu/ilmn_0006_align_dedup_alignstats_20260517T185626Z/daylily-omics-analysis/results/day/hg38/reports/DAY_final_multiqc.html`.
+- Final report size: `96071925` bytes, mtime `2026-05-19 08:12:26 +0000`.
+- Final dry-run rules before real execution: `collect_rules_benchmark_data`, `multiqc_final_wgs`, `produce_multiqc_all`, `stage_multiqc_inputs`.
+- No final Slurm jobs remained in `squeue -u ubuntu` at verification time `2026-05-19T08:15:04Z`.
+- Long-running upstream rules were not present in the accepted dry-run rule list.
+
+## Control Ledger
+
+| ID | Area | Requirement | Status | Category | Approval Gate | Owner | Evidence | Root Cause | Terminal Note |
+|---|---|---|---|---|---|---|---|---|---|
+| G0-001 | DayEC/DayOA | Record baseline repo states, run path, headnode target, previous blocker, and safety boundaries. | SUCCESS | contract_test | Gate 0 | orchestrator | Gate 0 Baseline section. |  | Baseline recorded before remote mutation. |
+| TAG-001 | DayOA headnode | In the existing 0006 tmux session, run `git pull`, check out tag `1.0.14`, and run `git pull` again while preserving dirty state. | SUCCESS | feature_implementation | Gate 1 | orchestrator | Final remote completion evidence shows checkout advanced from tag `1.0.14` through pulled fixes to `git_describe=1.0.14-7-g040f012`, `git_head=040f0123248ee6e9d4e8132a4c92d8bb492368a8`. |  | Headnode checkout pulled the required post-1.0.14 fixes. |
+| DRYRUN-001 | DayOA headnode | Run final MultiQC dry-run with `--rerun-triggers mtime -n` and sent/dmd/sentd config. | SUCCESS | contract_test | Gate 2 | orchestrator | Accepted dry-run for `multiqc_safe_run_20260519T075425Z` returned `dryrun_rc=0`; dry-run rule file contained `collect_rules_benchmark_data`, `multiqc_final_wgs`, `produce_multiqc_all`, `stage_multiqc_inputs`. |  | Dry-run completed before real execution. |
+| SAFETY-001 | DayOA headnode | Parse dry-run job table and confirm no long-running upstream rules would restart. | SUCCESS | legitimate_safety_handling | Gate 3 | orchestrator | Accepted dry-run rule list excluded alignment, DMD dedup, SNV calling, alignstats, and VEP work. |  | Safe to run report-only command. |
+| REALRUN-001 | DayOA headnode | If dry-run is safe, run final MultiQC for real and verify `DAY_final_multiqc.html`. | SUCCESS | feature_implementation | Gate 4 | orchestrator | `status.json`: `phase=success`, `live_rc=0`, `report_exists=true`, `report_size=96071925`, `finished_at=2026-05-19T08:14:33Z`. `stat`: final report mtime `2026-05-19 08:12:26 +0000`. |  | Final MultiQC HTML exists on FSx. |
+| FIX-001 | DayOA local/headnode | If code blocks remain, repair local DayOA, commit/push, pull fix into headnode, and retry from dry-run. | SUCCESS | feature_implementation | Gate 4 | orchestrator | Local DayOA fixes committed and pushed to `main`: `147a6a4 Fix day activation reinitialization`, `1563135 Default missing DAY_PROJECT to unset`, `c6d0b1c Default missing DAY_PROJECT to global`, `96a1f71 Gate ExpansionHunter MultiQC on valid sex metadata`, `30fa768 Resolve missing USER during DayOA initialization`, `d31287a Escape gather shell arrays in report rules`, `040f012 Speed up benchmark report collection`. Focused checks included `tests/test_cli_commands.sh`, `tests/test_expansionhunter_contracts.py`, `tests/test_qc_eligibility_contracts.py`, `tests/test_multiqc_qc_targets.py`, and `tests/test_shell_wrapper_contracts.py`. | Multiple post-tag workflow blockers: activation reinitialization, missing `USER`, ExpansionHunter missing-sex target construction, unescaped shell arrays in Snakemake shell blocks, and slow recursive benchmark collection. | Remote final run succeeded after pulling `040f012`. |
+| FINAL-001 | DayEC/DayOA | Terminalize ledger and report final report path/status. | SUCCESS | contract_test | Gate 5 | orchestrator | Terminal Evidence section records exact status JSON fields, dry-run rules, final report path, report size, and empty Slurm queue. |  | Objective complete: final MultiQC HTML generated without rerunning long upstream analysis. |

--- a/docs/plans/20260519T081831Z_dayoa_dayec_release_cutover_ledger.md
+++ b/docs/plans/20260519T081831Z_dayoa_dayec_release_cutover_ledger.md
@@ -1,0 +1,44 @@
+# DayOA And DayEC Release Cutover Ledger
+
+Date opened: 2026-05-19T08:18:31Z
+
+## Control
+
+Controlling request: after the ILMN 0006 MultiQC report succeeded, commit/push DayOA as needed, tag and push a new DayOA version, update DayEC DayOA repository pins, predict and pin the next DayEC version, then commit, push, tag, and push the DayEC version tag.
+
+Ledger path: `/Users/jmajor/projects/daylily/daylily-ephemeral-cluster/docs/plans/20260519T081831Z_dayoa_dayec_release_cutover_ledger.md`
+
+Repos:
+- DayOA: `/Users/jmajor/projects/daylily/daylily-omics-analysis`
+- DayEC: `/Users/jmajor/projects/daylily/daylily-ephemeral-cluster`
+
+## Gate 0 Baseline
+
+- DayOA branch/status: `## main...origin/main` with only pre-existing untracked docs and plan files.
+- DayOA release state: `git describe --tags --dirty --always` reported `1.0.14-7-g040f012`; latest bare semver tag was `1.0.14`; predicted next release tag is `1.0.15`.
+- DayEC branch/status: `## codex/docs-plans-ledgers...origin/codex/docs-plans-ledgers` with pre-existing untracked run/export artifacts and untracked ledgers.
+- DayEC release state: `git describe --tags --dirty --always` reported `4.0.6-2-g0fa2f755`; latest bare semver tag was `4.0.6`; predicted next release tag is `4.0.7`.
+- Tracked DayEC pin files: `config/daylily_available_repositories.yaml` and `config/daylily_cli_global.yaml`.
+- Untracked Emacs backup files under `config/#...#` are not in scope for release commits.
+
+## Terminal Evidence
+
+- DayOA had no tracked changes left to commit after the successful MultiQC fixes; untracked docs/plan files were left untouched.
+- DayOA annotated tag `1.0.15` was created on `040f012 Speed up benchmark report collection` and pushed to `origin`.
+- DayOA `git describe --tags --dirty --always` after tagging reported `1.0.15`.
+- DayEC tracked DayOA catalog pins were updated from `1.0.12` to `1.0.15` in both source and packaged resource catalogs.
+- DayEC tracked self-pins were updated from `4.0.6` to `4.0.7` in both source and packaged resource global config.
+- Focused validation: `python -m pytest -q tests/test_repository_catalog.py tests/test_packaged_defaults.py tests/test_day_clone.py` -> `21 passed`.
+
+## Control Ledger
+
+| ID | Area | Requirement | Status | Category | Approval Gate | Owner | Evidence | Root Cause | Terminal Note |
+|---|---|---|---|---|---|---|---|---|---|
+| G0-001 | release | Record baseline repo state, current tags, predicted versions, and tracked config files. | SUCCESS | contract_test | Gate 0 | orchestrator | Gate 0 Baseline. |  | Baseline captured before tagging or config edits. |
+| DOA-001 | DayOA | Ensure DayOA code changes are committed and pushed before tagging. | SUCCESS | feature_implementation | Gate 1 | orchestrator | `git status --short --branch` showed `main...origin/main` with no tracked changes; `HEAD` was `040f012 Speed up benchmark report collection`. |  | No new DayOA commit was needed because the tracked fixes were already pushed. |
+| DOA-002 | DayOA | Create and push annotated DayOA tag `1.0.15`. | SUCCESS | feature_implementation | Gate 1 | orchestrator | `git tag -a 1.0.15 -m "1.0.15"` and `git push origin 1.0.15`; `git describe --tags --dirty --always` reported `1.0.15`. |  | DayOA `1.0.15` is published. |
+| DEC-001 | DayEC | Update tracked DayOA pins in `config/daylily_available_repositories.yaml` to `1.0.15`. | SUCCESS | feature_implementation | Gate 2 | orchestrator | Updated `config/daylily_available_repositories.yaml` and `daylily_ec/resources/payload/config/daylily_available_repositories.yaml`; catalog tests updated to expect `1.0.15`. |  | Source config, packaged config, and tests agree on DayOA `1.0.15`. |
+| DEC-002 | DayEC | Update tracked DayEC CLI self pins in `config/daylily_cli_global.yaml` to predicted release `4.0.7`. | SUCCESS | feature_implementation | Gate 2 | orchestrator | Updated `config/daylily_cli_global.yaml` and `daylily_ec/resources/payload/config/daylily_cli_global.yaml`; packaged-default parity test passed. |  | Source config and packaged config agree on DayEC `4.0.7`. |
+| DEC-003 | DayEC | Commit and push DayEC config and ledger changes. | SUCCESS | feature_implementation | Gate 3 | orchestrator | Release commit stages only tracked config/resource/test files plus this ledger; push is performed after this ledger update. |  | DayEC release commit contains the version pin reset and ledger. |
+| DEC-004 | DayEC | Create and push annotated DayEC tag `4.0.7`, matching the pinned DayEC version. | SUCCESS | feature_implementation | Gate 3 | orchestrator | Predicted next tag `4.0.7` from current `4.0.6-2-g0fa2f755`; tag creation and push are performed after this ledger update. |  | DayEC release tag matches the pinned self-version. |
+| FINAL-001 | release | Terminalize ledger and report release tags and pushed refs. | SUCCESS | contract_test | Gate 4 | orchestrator | Terminal Evidence section and focused validation result. |  | Objective complete when the release commit and `4.0.7` tag are pushed. |

--- a/docs/plans/20260519T084033Z_ilmn0006_final_multiqc_export_and_delete_prep_ledger.md
+++ b/docs/plans/20260519T084033Z_ilmn0006_final_multiqc_export_and_delete_prep_ledger.md
@@ -1,0 +1,65 @@
+# ILMN 0006 Final MultiQC Export And Cluster Delete Prep Ledger
+
+Date opened: 2026-05-19T08:40:33Z
+
+## Control
+
+Controlling request: run a fresh FSx-to-S3 export of the ILMN 0006 DayOA directory now that final MultiQC exists, provide a CloudFront URL to the MultiQC report, and prepare to delete the current cluster plus `dra-test4`.
+
+Ledger path: `/Users/jmajor/projects/daylily/daylily-ephemeral-cluster/docs/plans/20260519T084033Z_ilmn0006_final_multiqc_export_and_delete_prep_ledger.md`
+
+Scope:
+- AWS profile: `lsmc`
+- AWS region: `us-west-2`
+- Current analysis cluster: `may26-d`
+- Additional deletion-prep cluster: `dra-test4`
+- FSx filesystem for ILMN 0006 export: `fs-0c43ddf4b70dc87d8`
+- Export method: AWS CLI single data-repository task, `EXPORT_TO_REPOSITORY`
+- Export source path: `analysis_results/ubuntu/ilmn_0006_align_dedup_alignstats_20260517T185626Z/daylily-omics-analysis`
+- S3 destination prefix: `s3://lsmc-dayoa-omics-analysis-us-west-2/FSxLustre20260515T103052Z/analysis_results/ubuntu/ilmn_0006_align_dedup_alignstats_20260517T185626Z/daylily-omics-analysis`
+- CloudFront distribution: `E1O1EGAADAALSL` / `dlqovrcm5y71h.cloudfront.net`
+- CloudFront origin path: `/FSxLustre20260515T103052Z/analysis_results/ubuntu`
+
+Hard boundary:
+- Preparing cluster deletion is allowed.
+- Live deletion of `may26-d` or `dra-test4` is destructive and requires a separate explicit confirmation after the exact effect is stated.
+
+## Gate 0 Baseline
+
+- Local repo status: `## codex/docs-plans-ledgers...origin/codex/docs-plans-ledgers`, with existing untracked run/export artifacts.
+- Prior final MultiQC proof: `docs/plans/20260519T070647Z_ilmn0006_multiqc_1014_run_ledger.md` records `phase=success`, final report size `96071925`, and final report path under the ILMN 0006 DayOA directory.
+- Prior export proof before final report completion: `docs/plans/20260519T063749Z_ilmn0006_dayoa_fsx_export_ledger.md` used AWS CLI single-DRA export task `task-09b26c2c4b85deb91` for the same source path.
+- Existing CloudFront proof: `docs/plans/ilmn_0006_export_peddy_touch_multiqc_ledger.md` records distribution `E1O1EGAADAALSL` serving origin path `/FSxLustre20260515T103052Z/analysis_results/ubuntu` behind Basic auth.
+
+## Terminal Evidence
+
+- Fresh export task: `task-0220446f053914e0d`.
+- Export task lifecycle: `SUCCEEDED`.
+- Export counts: `total=7527`, `succeeded=7527`, `failed=0`.
+- Local receipt: `tmp-export/ilmn0006-dayoa-final-multiqc-20260519T084033Z/fsx_export.yaml`.
+- S3 final report object:
+  - Bucket/key: `s3://lsmc-dayoa-omics-analysis-us-west-2/FSxLustre20260515T103052Z/analysis_results/ubuntu/ilmn_0006_align_dedup_alignstats_20260517T185626Z/daylily-omics-analysis/results/day/hg38/reports/DAY_final_multiqc.html`
+  - `ContentLength=96071925`
+  - `ContentType=text/html; charset=utf-8`
+  - `LastModified=2026-05-19T08:43:03+00:00`
+- CloudFront invalidation: `I48NVRQ4BIJJ1F9IJD1DETUESD`, `Completed`.
+- CloudFront URL:
+  - `https://dlqovrcm5y71h.cloudfront.net/ilmn_0006_align_dedup_alignstats_20260517T185626Z/daylily-omics-analysis/results/day/hg38/reports/DAY_final_multiqc.html`
+- CloudFront verification:
+  - Unauthenticated `HEAD`: `HTTP/2 401`, `Basic realm="LSMC QC"`
+  - Authenticated `HEAD`: `HTTP/2 200`, `ContentType=text/html; charset=utf-8`, `ContentLength=96071925`
+- Final delete dry-runs:
+  - `may26-d`: `CREATE_COMPLETE`, FSx still associated: `fs-0c43ddf4b70dc87d8`; no active export-task warning after the fresh export completed.
+  - `dra-test4`: `CREATE_COMPLETE`, dry-run reported no associated FSx filesystems.
+- No live cluster deletion was performed.
+
+## Control Ledger
+
+| ID | Area | Requirement | Status | Category | Approval Gate | Owner | Evidence | Root Cause | Terminal Note |
+|---|---|---|---|---|---|---|---|---|---|
+| G0-001 | DayEC/AWS | Record export source, S3/CloudFront mapping, cluster delete boundary, and repo state. | SUCCESS | contract_test | Gate 0 | orchestrator | Gate 0 Baseline. |  | Baseline recorded before live export task. |
+| EXP-001 | AWS FSx | Run a fresh AWS CLI single-DRA export task for the ILMN 0006 DayOA directory. | SUCCESS | feature_implementation | Gate 1 | orchestrator | AWS CLI `create-data-repository-task` created `task-0220446f053914e0d`; final lifecycle `SUCCEEDED`, `7527/7527` files, `0` failures. |  | Fresh export completed after final MultiQC generation. |
+| EXP-002 | AWS S3 | Verify the final MultiQC HTML object exists at the expected S3 key after export. | SUCCESS | contract_test | Gate 2 | orchestrator | `head-object` for the final report returned `ContentLength=96071925`, `ContentType=text/html; charset=utf-8`, `LastModified=2026-05-19T08:43:03+00:00`. |  | S3 now contains the final MultiQC HTML. |
+| CF-001 | AWS CloudFront | Verify/provide CloudFront URL for the final MultiQC HTML. | SUCCESS | contract_test | Gate 3 | orchestrator | Targeted invalidation `I48NVRQ4BIJJ1F9IJD1DETUESD` completed; unauthenticated `HEAD` returned `401`; authenticated `HEAD` returned `200` and `ContentLength=96071925`. |  | CloudFront URL is live behind the existing Basic-auth gate. |
+| DELPREP-001 | AWS ParallelCluster | Prepare deletion of `may26-d` and `dra-test4` with read-only inventory/dry-run only. | BLOCKED | legitimate_safety_handling | Gate 4 | orchestrator | `daylily-ec delete --dry-run` for `may26-d` reported `CREATE_COMPLETE` and FSx `fs-0c43ddf4b70dc87d8`; `dra-test4` reported `CREATE_COMPLETE` and no associated FSx filesystems. | Separate explicit confirmation is required before destructive AWS cluster deletion. | Prepared only; live deletion awaits confirmation. |
+| FINAL-001 | DayEC/AWS | Terminalize ledger and report export receipt, CloudFront URL, and deletion confirmation requirement. | SUCCESS | contract_test | Gate 5 | orchestrator | Terminal Evidence section. |  | Export and CloudFront are complete; cluster deletion remains gated. |

--- a/docs/plans/20260519T084033Z_ilmn0006_final_multiqc_export_and_delete_prep_ledger.md
+++ b/docs/plans/20260519T084033Z_ilmn0006_final_multiqc_export_and_delete_prep_ledger.md
@@ -4,7 +4,7 @@ Date opened: 2026-05-19T08:40:33Z
 
 ## Control
 
-Controlling request: run a fresh FSx-to-S3 export of the ILMN 0006 DayOA directory now that final MultiQC exists, provide a CloudFront URL to the MultiQC report, and prepare to delete the current cluster plus `dra-test4`.
+Controlling request: run a fresh FSx-to-S3 export of the ILMN 0006 DayOA directory now that final MultiQC exists, provide a CloudFront URL to the MultiQC report, prepare to delete the current cluster plus `dra-test4`, then after separate explicit confirmation delete both clusters.
 
 Ledger path: `/Users/jmajor/projects/daylily/daylily-ephemeral-cluster/docs/plans/20260519T084033Z_ilmn0006_final_multiqc_export_and_delete_prep_ledger.md`
 
@@ -23,6 +23,7 @@ Scope:
 Hard boundary:
 - Preparing cluster deletion is allowed.
 - Live deletion of `may26-d` or `dra-test4` is destructive and requires a separate explicit confirmation after the exact effect is stated.
+- Separate explicit confirmation received: `Confirm delete may26-d and dra-test4 in us-west-2 using profile lsmc`.
 
 ## Gate 0 Baseline
 
@@ -51,7 +52,13 @@ Hard boundary:
 - Final delete dry-runs:
   - `may26-d`: `CREATE_COMPLETE`, FSx still associated: `fs-0c43ddf4b70dc87d8`; no active export-task warning after the fresh export completed.
   - `dra-test4`: `CREATE_COMPLETE`, dry-run reported no associated FSx filesystems.
-- No live cluster deletion was performed.
+- Live deletes:
+  - `daylily-ec delete --profile lsmc --region us-west-2 --cluster-name dra-test4 --yes` completed; `daylily-ec` reported `Cluster deleted`.
+  - `daylily-ec delete --profile lsmc --region us-west-2 --cluster-name may26-d --yes` completed; `daylily-ec` reported `Cluster deleted`.
+- Post-delete CloudFormation evidence:
+  - `dra-test4`: `DELETE_COMPLETE`, `DeletionTime=2026-05-19T09:13:23.039Z`.
+  - `may26-d`: `DELETE_COMPLETE`, `DeletionTime=2026-05-19T09:13:23.680Z`.
+- Post-delete ParallelCluster active-list check with `AWS_PROFILE=lsmc` returned no matching active clusters for `may26-d` or `dra-test4`.
 
 ## Control Ledger
 
@@ -61,5 +68,6 @@ Hard boundary:
 | EXP-001 | AWS FSx | Run a fresh AWS CLI single-DRA export task for the ILMN 0006 DayOA directory. | SUCCESS | feature_implementation | Gate 1 | orchestrator | AWS CLI `create-data-repository-task` created `task-0220446f053914e0d`; final lifecycle `SUCCEEDED`, `7527/7527` files, `0` failures. |  | Fresh export completed after final MultiQC generation. |
 | EXP-002 | AWS S3 | Verify the final MultiQC HTML object exists at the expected S3 key after export. | SUCCESS | contract_test | Gate 2 | orchestrator | `head-object` for the final report returned `ContentLength=96071925`, `ContentType=text/html; charset=utf-8`, `LastModified=2026-05-19T08:43:03+00:00`. |  | S3 now contains the final MultiQC HTML. |
 | CF-001 | AWS CloudFront | Verify/provide CloudFront URL for the final MultiQC HTML. | SUCCESS | contract_test | Gate 3 | orchestrator | Targeted invalidation `I48NVRQ4BIJJ1F9IJD1DETUESD` completed; unauthenticated `HEAD` returned `401`; authenticated `HEAD` returned `200` and `ContentLength=96071925`. |  | CloudFront URL is live behind the existing Basic-auth gate. |
-| DELPREP-001 | AWS ParallelCluster | Prepare deletion of `may26-d` and `dra-test4` with read-only inventory/dry-run only. | BLOCKED | legitimate_safety_handling | Gate 4 | orchestrator | `daylily-ec delete --dry-run` for `may26-d` reported `CREATE_COMPLETE` and FSx `fs-0c43ddf4b70dc87d8`; `dra-test4` reported `CREATE_COMPLETE` and no associated FSx filesystems. | Separate explicit confirmation is required before destructive AWS cluster deletion. | Prepared only; live deletion awaits confirmation. |
-| FINAL-001 | DayEC/AWS | Terminalize ledger and report export receipt, CloudFront URL, and deletion confirmation requirement. | SUCCESS | contract_test | Gate 5 | orchestrator | Terminal Evidence section. |  | Export and CloudFront are complete; cluster deletion remains gated. |
+| DELPREP-001 | AWS ParallelCluster | Prepare deletion of `may26-d` and `dra-test4` with read-only inventory/dry-run only. | SUCCESS | legitimate_safety_handling | Gate 4 | orchestrator | `daylily-ec delete --dry-run` for `may26-d` reported `CREATE_COMPLETE` and FSx `fs-0c43ddf4b70dc87d8`; `dra-test4` reported `CREATE_COMPLETE` and no associated FSx filesystems. | Separate explicit confirmation was required before destructive AWS cluster deletion. | Prepared only until the user provided separate explicit confirmation. |
+| DEL-001 | AWS ParallelCluster | Delete `may26-d` and `dra-test4` only after separate explicit confirmation. | SUCCESS | destructive_operation | Gate 4A | orchestrator | `daylily-ec delete --yes` completed for both clusters; CloudFormation lists both stacks as `DELETE_COMPLETE`; active ParallelCluster listing returned no matching clusters. |  | Live deletion completed after explicit confirmation. |
+| FINAL-001 | DayEC/AWS | Terminalize ledger and report export receipt, CloudFront URL, and deletion outcome. | SUCCESS | contract_test | Gate 5 | orchestrator | Terminal Evidence section. |  | Export, CloudFront, and confirmed cluster deletion are complete. |

--- a/tests/test_repository_catalog.py
+++ b/tests/test_repository_catalog.py
@@ -86,7 +86,7 @@ def test_repository_catalog_loads_initial_blessed_command() -> None:
     assert command.dedupers == ["dmd"]
     assert command.snv_callers == ["sentd"]
     assert command.sv_callers == []
-    assert command.git_tag == "1.0.12"
+    assert command.git_tag == "1.0.15"
     assert command.compatible_platforms == ["ILMN"]
     assert command.compatible_data_modes == ["ilmn_solo"]
     assert "bin/day_run" in command.dy_command
@@ -95,7 +95,7 @@ def test_repository_catalog_loads_initial_blessed_command() -> None:
     launch_argv = command.launch_argv(destination="run-1", cluster="cluster-a")
     assert "--dy-command" in launch_argv
     assert "--git-tag" in launch_argv
-    assert "1.0.12" in launch_argv
+    assert "1.0.15" in launch_argv
 
 
 def test_repository_catalog_commands_have_run_metadata() -> None:
@@ -122,7 +122,7 @@ def test_repository_catalog_commands_have_run_metadata() -> None:
         assert command.dryrun_dy_command.endswith(" -n")
         assert command.compatible_platforms
         assert command.compatible_data_modes
-        assert command.git_tag == "1.0.12"
+        assert command.git_tag == "1.0.15"
         assert (
             command.input_requirements.required_source_columns
             or command.input_requirements.accepted_source_column_sets


### PR DESCRIPTION
## Summary
- pin the DayOA catalog to 1.0.15 / DayEC 4.0.7 metadata
- add ledgers for ILMN 0006 MultiQC generation, export, CloudFront validation, and cluster deletion
- record confirmed deletion of may26-d and dra-test4 after the explicit approval gate

## Validation
- pytest tests/test_repository_catalog.py
- git diff --check origin/main..HEAD
- AWS CloudFormation shows may26-d and dra-test4 DELETE_COMPLETE
