### PR TITLE
[codex] Pin DayOA 5.0.0 in DYEC

### DIFF
--- a/.github/workflows/update-badges.yml
+++ b/.github/workflows/update-badges.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           mkdir -p .badges
           # newest tag by *creation date* (not semver)
-          LATEST_TAG="$(git for-each-ref --sort=-creatordate --format='%(refname:strip=2)' refs/tags | head -n1)"
+          LATEST_TAG="$(git for-each-ref --sort=-creatordate --format='%(refname:strip=2)' refs/tags | sed -n '1p')"
           echo "latest_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Write latest_tag.json

--- a/config/daylily_cli_global.yaml
+++ b/config/daylily_cli_global.yaml
@@ -1,7 +1,7 @@
 ---
 daylily:
-  git_ephemeral_cluster_repo_tag: 5.1.34
-  git_ephemeral_cluster_repo_release_tag: 5.1.34
+  git_ephemeral_cluster_repo_tag: 5.1.36
+  git_ephemeral_cluster_repo_release_tag: 5.1.36
   git_ephemeral_cluster_repo: https://github.com/Daylily-Informatics/daylily-ephemeral-cluster.git
   analysis_root: /fsx/analysis_results/
   sentieon_lic_path: /fsx/references/runtime_assets/cached_envs/Life_Sciences_Manufacturing_Corporation_eval.lic

--- a/config/daylily_pipeline_command_catalog.yaml
+++ b/config/daylily_pipeline_command_catalog.yaml
@@ -193,12 +193,12 @@ repositories:
     description: "Primary whole genome and multiomics workflows."
     https_url: https://github.com/Daylily-Informatics/daylily-omics-analysis.git
     ssh_url: git@github.com:Daylily-Informatics/daylily-omics-analysis.git
-    default_ref: 0.7.753
+    default_ref: 5.0.0
     relative_path: daylily-omics-analysis
     analysis_commands:
       - command_id: simple-test
         type: test
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: none
         display_name: "Simple Test"
         description: "Smoke-test DayOA shell initialization and local help target without staged sample inputs."
@@ -224,12 +224,12 @@ repositories:
           - local
         compatible_data_modes:
           - none
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: true
         validation_runs: []
       - command_id: illumina_snv_alignstats
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Illumina SNV + Alignstats"
         description: "Illumina WGS Sentieon DNAscope and alignment-statistics launch profile."
@@ -265,7 +265,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - ilmn_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -289,7 +289,7 @@ repositories:
             notes: "Live run completed with CRAM, VCF, alignstats, and concordance outputs."
       - command_id: illumina_snv_alignstats_relatedness_vep_multiqc
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Illumina SNV + Alignstats + Relatedness + VEP MultiQC"
         description: "Illumina WGS Sentieon DNAscope, alignment statistics, relatedness, VEP annotation, and final MultiQC launch profile."
@@ -328,7 +328,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - ilmn_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         artifact_registration: &dayoa_multiqc_artifact_registration
           enabled: true
@@ -400,7 +400,7 @@ repositories:
             notes: "Live run completed with CRAM, VCF, alignstats, concordance, MultiQC, and relatedness outputs."
       - command_id: illumina_hg002_kitchensink_multiqc
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Illumina HG002 Kitchen Sink MultiQC"
         description: "HG002 Illumina WGS Sentieon DNAscope, dmd CRAM, concordance, relatedness, contamination identity, VEP, ExpansionHunter, HTD, metagenomics, and final MultiQC validation profile."
@@ -447,7 +447,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - ilmn_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         artifact_registration: *dayoa_multiqc_artifact_registration
         validation_runs:
@@ -472,7 +472,7 @@ repositories:
             notes: "Headnode run used the dy-r alias with the same targets/config on the 2.0.17 clone plus local stabilization patches that were mirrored into DayOA release 2.0.19; final report was results/day/hg38/reports/DAY_final_multiqc.html."
       - command_id: ultima_snv_alignstats
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Ultima SNV + Alignstats"
         description: "Ultima CRAM/FASTQ Sentieon DNAscope and alignment-statistics launch profile."
@@ -507,7 +507,7 @@ repositories:
           - ULTIMA
         compatible_data_modes:
           - ultima_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -531,7 +531,7 @@ repositories:
             notes: "Live run completed with VCF, alignstats, and concordance outputs."
       - command_id: ultima_snv_alignstats_kitchensink
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Ultima SNV + Alignstats Kitchen Sink"
         description: "Ultima CRAM/FASTQ Sentieon DNAscope, alignment statistics, relatedness, VEP annotation, and final MultiQC launch profile."
@@ -569,12 +569,12 @@ repositories:
           - ULTIMA
         compatible_data_modes:
           - ultima_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         artifact_registration: *dayoa_multiqc_artifact_registration
       - command_id: ont_snv_alignstats
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "ONT SNV + Alignstats"
         description: "ONT alignment, Sentieon DNAscope, and alignment-statistics launch profile."
@@ -610,7 +610,7 @@ repositories:
           - ONT
         compatible_data_modes:
           - ont_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -634,7 +634,7 @@ repositories:
             notes: "Live run completed with VCF, alignstats, and concordance outputs."
       - command_id: ont_snv_alignstats_kitchensink
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "ONT SNV + Alignstats Kitchen Sink"
         description: "ONT alignment, Sentieon DNAscope, alignment statistics, relatedness, VEP annotation, and final MultiQC launch profile."
@@ -673,12 +673,12 @@ repositories:
           - ONT
         compatible_data_modes:
           - ont_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         artifact_registration: *dayoa_multiqc_artifact_registration
       - command_id: pacbio_snv_alignstats
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "PacBio SNV + Alignstats"
         description: "PacBio HiFi Sentieon DeepVariant and alignment-statistics launch profile."
@@ -714,7 +714,7 @@ repositories:
           - PACBIO
         compatible_data_modes:
           - pacbio_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -738,7 +738,7 @@ repositories:
             notes: "Live run completed with CRAM, VCF, alignstats, and concordance outputs."
       - command_id: roche_snv_alignstats
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Roche SNV + Alignstats"
         description: "Roche aligned BAM Sentieon DNAscope and alignment-statistics launch profile."
@@ -773,7 +773,7 @@ repositories:
           - ROCHE
         compatible_data_modes:
           - roche_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -796,7 +796,7 @@ repositories:
             failure_cause: "Dry-run failed while preparing Roche/GATK containers: missing Singularity image /fsx/resources/environments/containers/ubuntu/ip-10-0-0-103/7a424a40c6fd659f4d052893dd3554fa.simg."
       - command_id: hybrid_ilmn_ont_snv
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Hybrid ILMN+ONT HIOMR SNV/SV"
         description: "Hybrid Illumina plus ONT refactored Sentieon HIOMR SNV/SV launch profile."
@@ -835,7 +835,7 @@ repositories:
           - ONT
         compatible_data_modes:
           - hybrid_ilmn_ont
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -859,7 +859,7 @@ repositories:
             notes: "Live run completed with sentdhiomr SNV/SV and concordance outputs."
       - command_id: hybrid_ilmn_ont_snv_kitchensink
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Hybrid ILMN+ONT HIOMR SNV/SV Kitchen Sink"
         description: "Hybrid Illumina plus ONT refactored Sentieon HIOMR SNV/SV, relatedness, VEP annotation, and final MultiQC launch profile."
@@ -901,12 +901,12 @@ repositories:
           - ONT
         compatible_data_modes:
           - hybrid_ilmn_ont
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         artifact_registration: *dayoa_multiqc_artifact_registration
       - command_id: inflection-bjuice-product-v0.1
         type: dev
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Inflection BJuice Product v0.1"
         description: "Inflection hybrid Illumina plus ONT HIOMR product profile with align, dmd CRAM, SNV, SV, CNV, mito, segdup limited to CYP11B1/NCF1/SMN1, expansionhunter, and concordance targets."
@@ -951,11 +951,11 @@ repositories:
           - ONT
         compatible_data_modes:
           - hybrid_ilmn_ont
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
       - command_id: hybrid_ultima_ont_snv
         type: dev
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Hybrid Ultima+ONT HUOMR SNV"
         description: "Hybrid Ultima plus ONT refactored modular Sentieon HUOMR SNV launch profile."
@@ -994,7 +994,7 @@ repositories:
           - ONT
         compatible_data_modes:
           - hybrid_ug_ont
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -1019,7 +1019,7 @@ repositories:
             notes: "Dry-run passed; live failure was new after the r-suffix command and pass-through staging avoided the prior basename collision."
       - command_id: complete_genomics_mgi_snv_concordance
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Complete Genomics/MGI SNV + Concordance"
         description: "Complete Genomics/MGI Sentieon sentcg/dmd/cgt7p launch profile."
@@ -1055,7 +1055,7 @@ repositories:
           - CG/MGI
         compatible_data_modes:
           - complete_genomics_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -1077,7 +1077,7 @@ repositories:
             failure_cause: "Blocked before dry-run because the candidate mate pair was not verified: _386_1 was 90,600,002,744 bytes, _386_2 was 10,794,018,984 bytes, and nearby _388_2 was 97,844,317,264 bytes."
       - command_id: illumina_run_qc
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: illumina_run_directory
         display_name: "Illumina Run QC"
         description: "Illumina run-folder QC from a mounted or explicit S3 run context."
@@ -1108,7 +1108,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -1131,7 +1131,7 @@ repositories:
             failure_cause: "Dry-run failed: WorkflowError reported config/units.tsv was not found and requested config/units.tsv or --config units_table=/path/to/units.tsv."
       - command_id: illumina_bclconvert
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: bclconvert_0_mm
         display_name: "Illumina nf-core BCL Convert"
         description: "Illumina demultiplexing through the pinned nf-core/bclconvert 4.0.3 container from a mounted run directory, with generated units table, demux metric TSVs, and focused BCL Convert MultiQC. This command does not run FastQC."
@@ -1161,7 +1161,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -1184,7 +1184,7 @@ repositories:
             failure_cause: "Dry-run failed: WorkflowError reported no read pairs specified for analysis unit 20260514_LH01106_0009_B23TVLGLT4."
       - command_id: illumina_run_qc_bclconvert
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: bclconvert_0_mm
         display_name: "Illumina Run QC + nf-core BCL Convert"
         description: "Mounted Illumina run-folder QC plus demultiplexing through the pinned nf-core/bclconvert 4.0.3 container, generated units, demux metric TSVs, and focused BCL Convert MultiQC in one run-analysis output tree. This command does not run FastQC."
@@ -1214,7 +1214,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         artifact_registration:
           enabled: true
@@ -1253,7 +1253,7 @@ repositories:
         validation_runs: []
       - command_id: ont_run_qc
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: ont_run_directory
         display_name: "ONT Run QC"
         description: "ONT mounted run-folder QC in one run-analysis output tree."
@@ -1284,7 +1284,7 @@ repositories:
           - ONT
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -1307,7 +1307,7 @@ repositories:
             failure_cause: "Dry-run failed: WorkflowError reported config/units.tsv was not found and requested config/units.tsv or --config units_table=/path/to/units.tsv."
       - command_id: ultima_run_qc
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: ultima_run_directory
         display_name: "Ultima Run QC"
         description: "Ultima run-folder QC from a mounted run context."
@@ -1338,7 +1338,7 @@ repositories:
           - ULTIMA
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation

--- a/daylily_ec/resources/payload/config/daylily_cli_global.yaml
+++ b/daylily_ec/resources/payload/config/daylily_cli_global.yaml
@@ -1,7 +1,7 @@
 ---
 daylily:
-  git_ephemeral_cluster_repo_tag: 5.1.34
-  git_ephemeral_cluster_repo_release_tag: 5.1.34
+  git_ephemeral_cluster_repo_tag: 5.1.36
+  git_ephemeral_cluster_repo_release_tag: 5.1.36
   git_ephemeral_cluster_repo: https://github.com/Daylily-Informatics/daylily-ephemeral-cluster.git
   analysis_root: /fsx/analysis_results/
   sentieon_lic_path: /fsx/references/runtime_assets/cached_envs/Life_Sciences_Manufacturing_Corporation_eval.lic

--- a/daylily_ec/resources/payload/config/daylily_pipeline_command_catalog.yaml
+++ b/daylily_ec/resources/payload/config/daylily_pipeline_command_catalog.yaml
@@ -193,12 +193,12 @@ repositories:
     description: "Primary whole genome and multiomics workflows."
     https_url: https://github.com/Daylily-Informatics/daylily-omics-analysis.git
     ssh_url: git@github.com:Daylily-Informatics/daylily-omics-analysis.git
-    default_ref: 0.7.753
+    default_ref: 5.0.0
     relative_path: daylily-omics-analysis
     analysis_commands:
       - command_id: simple-test
         type: test
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: none
         display_name: "Simple Test"
         description: "Smoke-test DayOA shell initialization and local help target without staged sample inputs."
@@ -224,12 +224,12 @@ repositories:
           - local
         compatible_data_modes:
           - none
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: true
         validation_runs: []
       - command_id: illumina_snv_alignstats
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Illumina SNV + Alignstats"
         description: "Illumina WGS Sentieon DNAscope and alignment-statistics launch profile."
@@ -265,7 +265,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - ilmn_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -289,7 +289,7 @@ repositories:
             notes: "Live run completed with CRAM, VCF, alignstats, and concordance outputs."
       - command_id: illumina_snv_alignstats_relatedness_vep_multiqc
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Illumina SNV + Alignstats + Relatedness + VEP MultiQC"
         description: "Illumina WGS Sentieon DNAscope, alignment statistics, relatedness, VEP annotation, and final MultiQC launch profile."
@@ -328,7 +328,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - ilmn_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         artifact_registration: &dayoa_multiqc_artifact_registration
           enabled: true
@@ -400,7 +400,7 @@ repositories:
             notes: "Live run completed with CRAM, VCF, alignstats, concordance, MultiQC, and relatedness outputs."
       - command_id: illumina_hg002_kitchensink_multiqc
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Illumina HG002 Kitchen Sink MultiQC"
         description: "HG002 Illumina WGS Sentieon DNAscope, dmd CRAM, concordance, relatedness, contamination identity, VEP, ExpansionHunter, HTD, metagenomics, and final MultiQC validation profile."
@@ -447,7 +447,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - ilmn_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         artifact_registration: *dayoa_multiqc_artifact_registration
         validation_runs:
@@ -472,7 +472,7 @@ repositories:
             notes: "Headnode run used the dy-r alias with the same targets/config on the 2.0.17 clone plus local stabilization patches that were mirrored into DayOA release 2.0.19; final report was results/day/hg38/reports/DAY_final_multiqc.html."
       - command_id: ultima_snv_alignstats
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Ultima SNV + Alignstats"
         description: "Ultima CRAM/FASTQ Sentieon DNAscope and alignment-statistics launch profile."
@@ -507,7 +507,7 @@ repositories:
           - ULTIMA
         compatible_data_modes:
           - ultima_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -531,7 +531,7 @@ repositories:
             notes: "Live run completed with VCF, alignstats, and concordance outputs."
       - command_id: ultima_snv_alignstats_kitchensink
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Ultima SNV + Alignstats Kitchen Sink"
         description: "Ultima CRAM/FASTQ Sentieon DNAscope, alignment statistics, relatedness, VEP annotation, and final MultiQC launch profile."
@@ -569,12 +569,12 @@ repositories:
           - ULTIMA
         compatible_data_modes:
           - ultima_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         artifact_registration: *dayoa_multiqc_artifact_registration
       - command_id: ont_snv_alignstats
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "ONT SNV + Alignstats"
         description: "ONT alignment, Sentieon DNAscope, and alignment-statistics launch profile."
@@ -610,7 +610,7 @@ repositories:
           - ONT
         compatible_data_modes:
           - ont_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -634,7 +634,7 @@ repositories:
             notes: "Live run completed with VCF, alignstats, and concordance outputs."
       - command_id: ont_snv_alignstats_kitchensink
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "ONT SNV + Alignstats Kitchen Sink"
         description: "ONT alignment, Sentieon DNAscope, alignment statistics, relatedness, VEP annotation, and final MultiQC launch profile."
@@ -673,12 +673,12 @@ repositories:
           - ONT
         compatible_data_modes:
           - ont_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         artifact_registration: *dayoa_multiqc_artifact_registration
       - command_id: pacbio_snv_alignstats
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "PacBio SNV + Alignstats"
         description: "PacBio HiFi Sentieon DeepVariant and alignment-statistics launch profile."
@@ -714,7 +714,7 @@ repositories:
           - PACBIO
         compatible_data_modes:
           - pacbio_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -738,7 +738,7 @@ repositories:
             notes: "Live run completed with CRAM, VCF, alignstats, and concordance outputs."
       - command_id: roche_snv_alignstats
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Roche SNV + Alignstats"
         description: "Roche aligned BAM Sentieon DNAscope and alignment-statistics launch profile."
@@ -773,7 +773,7 @@ repositories:
           - ROCHE
         compatible_data_modes:
           - roche_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -796,7 +796,7 @@ repositories:
             failure_cause: "Dry-run failed while preparing Roche/GATK containers: missing Singularity image /fsx/resources/environments/containers/ubuntu/ip-10-0-0-103/7a424a40c6fd659f4d052893dd3554fa.simg."
       - command_id: hybrid_ilmn_ont_snv
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Hybrid ILMN+ONT HIOMR SNV/SV"
         description: "Hybrid Illumina plus ONT refactored Sentieon HIOMR SNV/SV launch profile."
@@ -835,7 +835,7 @@ repositories:
           - ONT
         compatible_data_modes:
           - hybrid_ilmn_ont
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -859,7 +859,7 @@ repositories:
             notes: "Live run completed with sentdhiomr SNV/SV and concordance outputs."
       - command_id: hybrid_ilmn_ont_snv_kitchensink
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Hybrid ILMN+ONT HIOMR SNV/SV Kitchen Sink"
         description: "Hybrid Illumina plus ONT refactored Sentieon HIOMR SNV/SV, relatedness, VEP annotation, and final MultiQC launch profile."
@@ -901,12 +901,12 @@ repositories:
           - ONT
         compatible_data_modes:
           - hybrid_ilmn_ont
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         artifact_registration: *dayoa_multiqc_artifact_registration
       - command_id: inflection-bjuice-product-v0.1
         type: dev
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Inflection BJuice Product v0.1"
         description: "Inflection hybrid Illumina plus ONT HIOMR product profile with align, dmd CRAM, SNV, SV, CNV, mito, segdup limited to CYP11B1/NCF1/SMN1, expansionhunter, and concordance targets."
@@ -951,11 +951,11 @@ repositories:
           - ONT
         compatible_data_modes:
           - hybrid_ilmn_ont
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
       - command_id: hybrid_ultima_ont_snv
         type: dev
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Hybrid Ultima+ONT HUOMR SNV"
         description: "Hybrid Ultima plus ONT refactored modular Sentieon HUOMR SNV launch profile."
@@ -994,7 +994,7 @@ repositories:
           - ONT
         compatible_data_modes:
           - hybrid_ug_ont
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -1019,7 +1019,7 @@ repositories:
             notes: "Dry-run passed; live failure was new after the r-suffix command and pass-through staging avoided the prior basename collision."
       - command_id: complete_genomics_mgi_snv_concordance
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: default_reads_slim
         display_name: "Complete Genomics/MGI SNV + Concordance"
         description: "Complete Genomics/MGI Sentieon sentcg/dmd/cgt7p launch profile."
@@ -1055,7 +1055,7 @@ repositories:
           - CG/MGI
         compatible_data_modes:
           - complete_genomics_solo
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -1077,7 +1077,7 @@ repositories:
             failure_cause: "Blocked before dry-run because the candidate mate pair was not verified: _386_1 was 90,600,002,744 bytes, _386_2 was 10,794,018,984 bytes, and nearby _388_2 was 97,844,317,264 bytes."
       - command_id: illumina_run_qc
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: illumina_run_directory
         display_name: "Illumina Run QC"
         description: "Illumina run-folder QC from a mounted or explicit S3 run context."
@@ -1108,7 +1108,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -1131,7 +1131,7 @@ repositories:
             failure_cause: "Dry-run failed: WorkflowError reported config/units.tsv was not found and requested config/units.tsv or --config units_table=/path/to/units.tsv."
       - command_id: illumina_bclconvert
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: bclconvert_0_mm
         display_name: "Illumina nf-core BCL Convert"
         description: "Illumina demultiplexing through the pinned nf-core/bclconvert 4.0.3 container from a mounted run directory, with generated units table, demux metric TSVs, and focused BCL Convert MultiQC. This command does not run FastQC."
@@ -1161,7 +1161,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -1184,7 +1184,7 @@ repositories:
             failure_cause: "Dry-run failed: WorkflowError reported no read pairs specified for analysis unit 20260514_LH01106_0009_B23TVLGLT4."
       - command_id: illumina_run_qc_bclconvert
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: bclconvert_0_mm
         display_name: "Illumina Run QC + nf-core BCL Convert"
         description: "Mounted Illumina run-folder QC plus demultiplexing through the pinned nf-core/bclconvert 4.0.3 container, generated units, demux metric TSVs, and focused BCL Convert MultiQC in one run-analysis output tree. This command does not run FastQC."
@@ -1214,7 +1214,7 @@ repositories:
           - ILMN
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         artifact_registration:
           enabled: true
@@ -1253,7 +1253,7 @@ repositories:
         validation_runs: []
       - command_id: ont_run_qc
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: ont_run_directory
         display_name: "ONT Run QC"
         description: "ONT mounted run-folder QC in one run-analysis output tree."
@@ -1284,7 +1284,7 @@ repositories:
           - ONT
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation
@@ -1307,7 +1307,7 @@ repositories:
             failure_cause: "Dry-run failed: WorkflowError reported config/units.tsv was not found and requested config/units.tsv or --config units_table=/path/to/units.tsv."
       - command_id: ultima_run_qc
         type: prod
-        validated_version: 0.7.753
+        validated_version: 5.0.0
         test_data_profile: ultima_run_directory
         display_name: "Ultima Run QC"
         description: "Ultima run-folder QC from a mounted run context."
@@ -1338,7 +1338,7 @@ repositories:
           - ULTIMA
         compatible_data_modes:
           - run_directory_mount
-        git_tag: 0.7.753
+        git_tag: 5.0.0
         no_containerized: false
         validation_runs:
           - run_id: tstver411b_dayoa_catalog_recipe_validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "typer>=0.12,<1",
     "cli-core-yo==2.1.1",
-    "daylily-omics-analysis==0.7.753",
+    "daylily-omics-analysis==5.0.0",
     # aws-parallelcluster 3.13.x still imports pkg_resources at runtime.
     "setuptools<81",
     # Used by legacy bin/*.py tools (installed via setup.py script_files).


### PR DESCRIPTION
## Summary
- Pin canonical DayOA package and command catalog references to daylily-omics-analysis==5.0.0.
- Keep config/daylily_available_repositories.yaml and packaged available-repository symlinks pointing through the updated command catalog.
- Pin DYEC self-reference config values to 5.1.36 and tag the branch as 5.1.37.

## Validation
- TOML parsing confirmed daylily-omics-analysis==5.0.0.
- YAML parsing confirmed command catalog default_ref 5.0.0 and DYEC self-pins 5.1.36.
- git diff --check passed for edited files.

## Release Provenance
- Intermediate tag: 5.1.36
- Branch release tag: 5.1.37
